### PR TITLE
fix(ci): resolve clippy 1.95.0 lints

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -116,8 +116,9 @@ mod tests {
     #[test]
     fn self_pid_produces_a_snapshot() {
         let mut sampler = LinuxSampler::new();
-        let snaps = sampler.sample_tree(std::process::id() as i32);
-        let me = snaps.iter().find(|s| s.pid == std::process::id() as i32).expect("self snapshot");
+        let pid = std::process::id().cast_signed();
+        let snaps = sampler.sample_tree(pid);
+        let me = snaps.iter().find(|s| s.pid == pid).expect("self snapshot");
         assert!(me.rss_bytes > 0, "expected non-zero RSS");
         assert!(me.vms_bytes > 0, "expected non-zero VMS");
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -96,7 +96,7 @@ fn instant_exit_yields_na_row() {
 }
 
 fn python3_available() -> bool {
-    Command::new("python3").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
+    Command::new("python3").arg("--version").output().is_ok_and(|o| o.status.success())
 }
 
 /// End-to-end check that the platform sampler observes resource usage


### PR DESCRIPTION
## Summary of changes

Two pedantic clippy lints fail on the stable 1.95.0 toolchain that the CI runner picked up but didn't fire on 1.94.0:

- `clippy::cast_possible_wrap` on `std::process::id() as i32` in `src/platform/linux.rs::tests::self_pid_produces_a_snapshot`. Switched to `u32::cast_signed()` so the bit-reinterpret is explicit. The macOS equivalent test already had an `#[allow(clippy::cast_possible_wrap)]` annotation; only the linux test was bare.
- `clippy::map_unwrap_or` on the `python3` probe in `tests/integration.rs::python3_available`. `Result::map(...).unwrap_or(false)` is now `is_ok_and(...)`.

No behavior change. Verified locally on 1.95.0 with `cargo ci-fmt`, `cargo ci-lint`, and `cargo ci-test` (34/34 passing).

### Issue(s) addressed by this PR

CI on the v0.1.0 push to `main` failed at the `lint (ubuntu-latest)` step with the two errors above. This unblocks `Check and Test`.

### Reviewer guidance

Both fixes are exactly what clippy's `help:` line suggested. The macOS lint job is gated by the same `#[allow]`s on the existing `as i32` casts and was not reported failing.

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Checklist

- [x] All CI checks pass locally (rustfmt, clippy, nextest)
- [x] No behavior change; only lint-driven refactors
- [x] No new public API surface