### PR TITLE
fix(test): stabilize macOS json_output_round_trips_to_object

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13,7 +13,14 @@ fn binary() -> PathBuf {
 }
 
 fn run_bench(out: &std::path::Path, format: &str, command: &[&str]) -> std::process::Output {
+    // Tighten the sampling interval well below the default 0.5 s so a sub-
+    // second workload still yields multiple samples even on a heavily-loaded
+    // CI runner. Without this, `sleep 0.6` could land in a single 0.5 s
+    // window that the sampler thread misses if it's late waking up — which
+    // is what caused `json_output_round_trips_to_object` to flake on
+    // macos-latest.
     let mut cmd = Command::new(binary());
+    cmd.args(["--interval", "0.1"]);
     cmd.arg("--out").arg(out).arg("--format").arg(format).arg("--");
     for piece in command {
         cmd.arg(piece);


### PR DESCRIPTION
## Summary of changes

`json_output_round_trips_to_object` flaked on `test (macos-latest)` immediately after PR #3 landed on `main` ([failing run](https://github.com/fg-labs/tricord/actions/runs/25038656290)). The test runs `sleep 0.6` and asserts that the JSON record's `data_collected` is `true`, but with the default 0.5 s sampling interval that workload gives the sampler exactly one polling window — and on a heavily-loaded `macos-latest` runner the sampler thread can wake just late enough that the child has already exited. Linux passed in the same run; the runner is faster.

The fix drops the integration test helper's `--interval` to 0.1 s, so sub-second workloads now yield multiple samples and the test is robust to runner scheduling latency.

### Issue(s) addressed by this PR

`main` CI failure following PR #3 merge — only `test (macos-latest)` was red.

### Reviewer guidance

- One-file diff in `tests/integration.rs::run_bench`.
- `instant_exit_yields_na_row` (`sh -c true`, exits in ~10 ms) still lands in the NA path with the new 100 ms first-sample window, and the test already tolerates either NA or numeric — verified locally.
- `end_to_end_resource_usage_against_known_workload` already passes its own `--interval 0.1` inline; it's unaffected.
- Local verification on Rust 1.95.0: `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` all pass (34/34).

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Checklist

- [x] All CI checks pass locally (rustfmt, clippy, nextest)
- [x] Test-only change; no production code touched
- [x] Comment in `run_bench` documents *why* the interval is tightened so a future contributor doesn't quietly revert it