### PR TITLE
feat(trace): per-tick TSV trace via --trace <PATH>

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ let options = RunOptions {
     output_path: std::path::Path::new("/tmp/timing.tsv").into(),
     format: OutputFormat::Tsv,
     force_summary: false,
+    trace_path: None,
 };
 let outcome = run_command("samtools", &["sort".into(), "in.bam".into()], &options).unwrap();
 println!("exit={} cpu_time={:.2}s", outcome.exit_code(), outcome.record.cpu_time);

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ both spreadsheets and pipelines.
 - **Two output formats** — Snakemake-compatible TSV by default, one-line
   JSON (`--format json`) for programmatic consumers.
 - **Optional one-line summary** to stderr (`--summary`).
+- **Optional per-tick trace** (`--trace <PATH>`) — one TSV row per sample, so
+  you can see how memory, I/O, and CPU evolved during the run instead of just
+  the final aggregate.
 - **Clean shutdown** — forwards `SIGINT` / `SIGTERM` / `SIGHUP` to the
   child's process group so orchestrators can tear runs down without
   leaking children.
@@ -72,6 +75,7 @@ Options:
       --format <FORMAT>      tsv | json [default: tsv]
       --interval <SECONDS>   Sampling interval [default: 0.5]
       --summary              Print one-line summary to stderr after the run
+      --trace <PATH>         Also write a per-tick TSV trace to this path
   -v, --verbose...           Increase log level (-v, -vv, -vvv)
   -h, --help                 Print help
   -V, --version              Print version
@@ -105,6 +109,30 @@ s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
 
 Missing values render as `-`; if the run was too short for any sample to
 succeed, every resource column is `NA`.
+
+### Per-tick trace (`--trace <PATH>`)
+
+When `--trace` is given, `tricorder` also writes a separate TSV with one row
+per sampling tick — useful for "did it spike or stay flat?" plots and for
+post-mortem on OOM kills. The aggregate `--out` file is unaffected.
+
+```text
+s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs
+0.5012	102.30	2048.00	95.20	96.00	1.25	0.50	0.75	3
+1.0027	120.45	2048.00	112.10	113.00	2.50	1.00	1.55	3
+1.5042	101.50	2048.00	95.20	96.00	2.50	1.00	2.40	2
+```
+
+| Column | Units | Meaning |
+|---|---|---|
+| `s` | seconds (`%.4f`) | Time since `tricorder` started |
+| `rss`, `vms`, `uss`, `pss` | MiB (`%.2f`) | **Instantaneous** sum across the live process tree at this tick |
+| `io_in`, `io_out` | MiB | **Cumulative** bytes read/written across every PID observed so far (including exited children) |
+| `cpu_time` | seconds | Cumulative user + system CPU time across observed PIDs |
+| `n_procs` | integer | Number of live processes in this tick |
+
+Memory columns are instantaneous, so they can go up *or down* between rows;
+I/O and CPU are cumulative, so they are monotonically non-decreasing.
 
 ### JSON (`--format json`)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,12 @@ pub struct Args {
     #[arg(long)]
     pub summary: bool,
 
+    /// Optional path for a per-tick TSV trace. When set, `tricorder` writes
+    /// one row per sample showing instantaneous memory and cumulative I/O
+    /// and CPU, alongside the aggregate `--out` file.
+    #[arg(long, value_name = "PATH")]
+    pub trace: Option<PathBuf>,
+
     /// Verbosity (each `-v` raises the log level: warn → info → debug → trace).
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub verbose: u8,
@@ -129,6 +135,26 @@ mod tests {
         let args =
             Args::parse_from(["tricorder", "--out", "x", "--interval", "1.25", "--", "true"]);
         assert_eq!(args.interval_duration(), Duration::from_millis(1250));
+    }
+
+    #[test]
+    fn parses_trace_path() {
+        let args = Args::parse_from([
+            "tricorder",
+            "--out",
+            "out.tsv",
+            "--trace",
+            "/tmp/trace.tsv",
+            "--",
+            "true",
+        ]);
+        assert_eq!(args.trace, Some(PathBuf::from("/tmp/trace.tsv")));
+    }
+
+    #[test]
+    fn trace_defaults_to_none() {
+        let args = Args::parse_from(["tricorder", "--out", "out.tsv", "--", "true"]);
+        assert!(args.trace.is_none());
     }
 
     #[test]

--- a/src/format.rs
+++ b/src/format.rs
@@ -38,14 +38,26 @@ pub fn write_to_path(
     path: &Path,
     format: OutputFormat,
 ) -> io::Result<()> {
+    ensure_parent_dir(path)?;
+    let file = File::create(path)?;
+    let mut writer = BufWriter::new(file);
+    write_to(record, &mut writer, format)?;
+    // Surface flush errors instead of letting BufWriter::drop swallow them.
+    writer.flush()
+}
+
+/// Create the parent directory of `path` if it has one and isn't empty.
+/// Used by both the aggregate output writer and the trace writer.
+///
+/// # Errors
+/// Returns any I/O error from `create_dir_all`.
+pub(crate) fn ensure_parent_dir(path: &Path) -> io::Result<()> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
     {
         std::fs::create_dir_all(parent)?;
     }
-    let file = File::create(path)?;
-    let mut writer = BufWriter::new(file);
-    write_to(record, &mut writer, format)
+    Ok(())
 }
 
 /// Serialize `record` into the given writer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //!     output_path: std::path::Path::new("/tmp/timing.tsv").into(),
 //!     format: OutputFormat::Tsv,
 //!     force_summary: false,
+//!     trace_path: None,
 //! };
 //! let outcome = run_command("echo", &["hello".to_string()], &options).unwrap();
 //! assert_eq!(outcome.exit_code(), 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 //! Entry point for the `tricorder` binary.
 
-use std::process::ExitCode;
+use std::{path::PathBuf, process::ExitCode};
 
 use clap::Parser;
 use tricord::{
@@ -25,6 +25,7 @@ fn main() -> ExitCode {
         output_path: args.out.clone().into_boxed_path(),
         format: args.format.into(),
         force_summary: args.summary,
+        trace_path: args.trace.clone().map(PathBuf::into_boxed_path),
     };
 
     match run_command(&command, &command_args, &options) {

--- a/src/record.rs
+++ b/src/record.rs
@@ -11,6 +11,58 @@ use serde::Serialize;
 pub const TSV_HEADER: &str =
     "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\tio_in\tio_out\tmean_load\tcpu_time";
 
+/// Tab-separated header for the per-tick trace TSV (`--trace`). Distinct from
+/// [`TSV_HEADER`] because the trace records *instantaneous* memory and
+/// *cumulative-so-far* I/O and CPU values; there is no `mean_load` or `h:m:s`
+/// column because those are only meaningful for the whole-run aggregate.
+pub const TRACE_TSV_HEADER: &str = "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs";
+
+/// One per-tick row of the trace TSV.
+///
+/// Memory fields (`rss`, `vms`, `uss`, `pss`) are summed across the *currently-
+/// live* process tree at that tick, in MiB. I/O and CPU fields are the running
+/// per-PID accumulators summed across *every* PID observed so far (including
+/// children that have already exited), so the values are monotonically
+/// non-decreasing across rows.
+#[derive(Debug, Clone, Default)]
+pub struct TickRecord {
+    /// Seconds since the sampler started.
+    pub elapsed: f64,
+    /// Summed RSS across live processes, MiB.
+    pub rss: f64,
+    /// Summed VMS across live processes, MiB.
+    pub vms: f64,
+    /// Summed USS across live processes, MiB. `None` if no process exposed it.
+    pub uss: Option<f64>,
+    /// Summed PSS across live processes, MiB. `None` if no process exposed it.
+    pub pss: Option<f64>,
+    /// Cumulative bytes read across observed PIDs, MiB. `None` if never seen.
+    pub io_in: Option<f64>,
+    /// Cumulative bytes written across observed PIDs, MiB. `None` if never seen.
+    pub io_out: Option<f64>,
+    /// Cumulative user + system CPU time across observed PIDs, seconds.
+    pub cpu_time: f64,
+    /// Number of live processes in this tick.
+    pub n_procs: usize,
+}
+
+impl TickRecord {
+    /// Render this tick as a single TSV row using `%.4f` for elapsed time,
+    /// `%.2f` for floats, `-` for missing optional values, and a bare integer
+    /// for `n_procs`.
+    #[must_use]
+    pub fn to_tsv_row(&self) -> String {
+        let mut out = String::with_capacity(96);
+        write!(out, "{:.4}\t{:.2}\t{:.2}", self.elapsed, self.rss, self.vms).unwrap();
+        for value in [self.uss, self.pss, self.io_in, self.io_out] {
+            out.push('\t');
+            out.push_str(&format_optional_float(value));
+        }
+        write!(out, "\t{:.2}\t{}", self.cpu_time, self.n_procs).unwrap();
+        out
+    }
+}
+
 /// One row of benchmark output: the aggregate of all samples taken across the run.
 ///
 /// Memory values are in MiB. `io_in` and `io_out` are in MiB. `running_time` and
@@ -232,6 +284,43 @@ mod tests {
         assert!(lines.next().is_some_and(|line| line.starts_with("0.5000\t")));
         assert_eq!(lines.next(), None);
         assert!(doc.ends_with('\n'));
+    }
+
+    #[test]
+    fn trace_header_lists_per_tick_columns() {
+        assert_eq!(TRACE_TSV_HEADER, "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs");
+    }
+
+    #[test]
+    fn tick_row_full_data() {
+        let tick = TickRecord {
+            elapsed: 0.5012,
+            rss: 102.30,
+            vms: 2048.0,
+            uss: Some(95.2),
+            pss: Some(96.0),
+            io_in: Some(1.25),
+            io_out: Some(0.5),
+            cpu_time: 0.75,
+            n_procs: 3,
+        };
+        assert_eq!(tick.to_tsv_row(), "0.5012\t102.30\t2048.00\t95.20\t96.00\t1.25\t0.50\t0.75\t3");
+    }
+
+    #[test]
+    fn tick_row_missing_optionals_render_as_dash() {
+        let tick = TickRecord {
+            elapsed: 1.0,
+            rss: 10.0,
+            vms: 20.0,
+            uss: None,
+            pss: None,
+            io_in: None,
+            io_out: None,
+            cpu_time: 0.0,
+            n_procs: 1,
+        };
+        assert_eq!(tick.to_tsv_row(), "1.0000\t10.00\t20.00\t-\t-\t-\t-\t0.00\t1");
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -45,6 +45,8 @@ pub struct RunOptions {
     /// If true, write a one-line summary to stderr after the child exits.
     /// If false but stderr is a terminal, still print the summary.
     pub force_summary: bool,
+    /// Optional path for a per-tick TSV trace. `None` disables the trace.
+    pub trace_path: Option<Box<Path>>,
 }
 
 /// Spawn `command` (with `args`), benchmark its process tree, and write the
@@ -73,7 +75,10 @@ pub fn run_command(command: &str, args: &[String], options: &RunOptions) -> io::
     // Install signal forwarding before the sampler so a fast Ctrl-C still
     // reaches the child even if the sampler thread hasn't started yet.
     let signals = SignalForwarder::install(child_pid)?;
-    let sampler = SamplerHandle::spawn(child_pid, SamplerOptions { interval: options.interval });
+    let sampler = SamplerHandle::spawn(
+        child_pid,
+        SamplerOptions { interval: options.interval, trace_path: options.trace_path.clone() },
+    );
 
     let status = child.wait()?;
     let record = sampler.stop();

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -15,6 +15,9 @@
 
 use std::{
     collections::HashMap,
+    fs::File,
+    io::{BufWriter, Write},
+    path::Path,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -23,7 +26,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{platform, record::BenchmarkRecord};
+use crate::{
+    format, platform,
+    record::{BenchmarkRecord, TRACE_TSV_HEADER, TickRecord},
+};
 
 /// Default sampling interval (matches `snakemake.benchmark.BENCHMARK_INTERVAL_SHORT`).
 pub const DEFAULT_INTERVAL: Duration = Duration::from_millis(500);
@@ -68,31 +74,97 @@ pub struct SamplerState {
     data_collected: bool,
 }
 
+/// Per-tick memory sums across the live tree. `uss` and `pss` are `None`
+/// when no process in this tick exposed the metric.
+struct MemorySums {
+    rss: u64,
+    vms: u64,
+    uss: Option<u64>,
+    pss: Option<u64>,
+}
+
+/// Cumulative I/O and CPU totals across every PID observed so far. `io_in`
+/// and `io_out` are `None` when no process has ever exposed I/O counters.
+struct CumulativeTotals {
+    io_in: Option<u64>,
+    io_out: Option<u64>,
+    cpu_time: f64,
+}
+
+/// Sum memory across the snapshots in a single tick.
+fn sum_memory(snapshots: &[ProcessSnapshot]) -> MemorySums {
+    let mut rss: u64 = 0;
+    let mut vms: u64 = 0;
+    let mut uss: u64 = 0;
+    let mut pss: u64 = 0;
+    let mut any_uss = false;
+    let mut any_pss = false;
+    for snap in snapshots {
+        rss = rss.saturating_add(snap.rss_bytes);
+        vms = vms.saturating_add(snap.vms_bytes);
+        if let Some(v) = snap.uss_bytes {
+            uss = uss.saturating_add(v);
+            any_uss = true;
+        }
+        if let Some(v) = snap.pss_bytes {
+            pss = pss.saturating_add(v);
+            any_pss = true;
+        }
+    }
+    MemorySums {
+        rss,
+        vms,
+        uss: if any_uss { Some(uss) } else { None },
+        pss: if any_pss { Some(pss) } else { None },
+    }
+}
+
+/// Sum the per-PID accumulators for I/O and CPU. Includes PIDs whose
+/// processes have already exited (last-observed value persists).
+fn cumulative_totals(per_pid: &HashMap<i32, ProcessAccum>) -> CumulativeTotals {
+    let mut io_in: u64 = 0;
+    let mut io_out: u64 = 0;
+    let mut any_io_in = false;
+    let mut any_io_out = false;
+    let mut cpu_time = 0.0_f64;
+    for accum in per_pid.values() {
+        if let Some(v) = accum.io_read_bytes {
+            io_in = io_in.saturating_add(v);
+            any_io_in = true;
+        }
+        if let Some(v) = accum.io_write_bytes {
+            io_out = io_out.saturating_add(v);
+            any_io_out = true;
+        }
+        cpu_time += accum.cpu_time_seconds;
+    }
+    CumulativeTotals {
+        io_in: if any_io_in { Some(io_in) } else { None },
+        io_out: if any_io_out { Some(io_out) } else { None },
+        cpu_time,
+    }
+}
+
+fn bytes_to_mib(bytes: u64) -> f64 {
+    (bytes as f64) / (1024.0 * 1024.0)
+}
+
 impl SamplerState {
     /// Fold one tick's worth of snapshots into the running aggregate.
     pub fn absorb(&mut self, snapshots: &[ProcessSnapshot]) {
         if snapshots.is_empty() {
             return;
         }
-        let mut tick_rss: u64 = 0;
-        let mut tick_vms: u64 = 0;
-        let mut tick_uss_total: u64 = 0;
-        let mut tick_pss_total: u64 = 0;
-        let mut any_uss = false;
-        let mut any_pss = false;
-
+        let sums = sum_memory(snapshots);
+        self.max_rss_bytes = self.max_rss_bytes.max(sums.rss);
+        self.max_vms_bytes = self.max_vms_bytes.max(sums.vms);
+        if let Some(v) = sums.uss {
+            self.max_uss_bytes = Some(self.max_uss_bytes.unwrap_or(0).max(v));
+        }
+        if let Some(v) = sums.pss {
+            self.max_pss_bytes = Some(self.max_pss_bytes.unwrap_or(0).max(v));
+        }
         for snap in snapshots {
-            tick_rss = tick_rss.saturating_add(snap.rss_bytes);
-            tick_vms = tick_vms.saturating_add(snap.vms_bytes);
-            if let Some(v) = snap.uss_bytes {
-                tick_uss_total = tick_uss_total.saturating_add(v);
-                any_uss = true;
-            }
-            if let Some(v) = snap.pss_bytes {
-                tick_pss_total = tick_pss_total.saturating_add(v);
-                any_pss = true;
-            }
-
             let entry = self.per_pid.entry(snap.pid).or_default();
             if let Some(io_in) = snap.io_read_bytes {
                 entry.io_read_bytes = Some(io_in.max(entry.io_read_bytes.unwrap_or(0)));
@@ -104,24 +176,40 @@ impl SamplerState {
                 entry.cpu_time_seconds = snap.cpu_time_seconds;
             }
         }
-
-        self.max_rss_bytes = self.max_rss_bytes.max(tick_rss);
-        self.max_vms_bytes = self.max_vms_bytes.max(tick_vms);
-        if any_uss {
-            self.max_uss_bytes = Some(self.max_uss_bytes.unwrap_or(0).max(tick_uss_total));
-        }
-        if any_pss {
-            self.max_pss_bytes = Some(self.max_pss_bytes.unwrap_or(0).max(tick_pss_total));
-        }
         self.data_collected = true;
+    }
+
+    /// Build a per-tick [`TickRecord`] from `snapshots` (the just-sampled
+    /// live processes) plus this state's running cumulative I/O and CPU
+    /// totals. Returns `None` when `snapshots` is empty (nothing to record).
+    ///
+    /// Memory totals are instantaneous (summed across `snapshots`); I/O and
+    /// CPU are cumulative across every PID observed so far, including
+    /// children that have already exited.
+    #[must_use]
+    pub fn tick(&self, snapshots: &[ProcessSnapshot], elapsed_seconds: f64) -> Option<TickRecord> {
+        if snapshots.is_empty() {
+            return None;
+        }
+        let mem = sum_memory(snapshots);
+        let cum = cumulative_totals(&self.per_pid);
+        Some(TickRecord {
+            elapsed: elapsed_seconds,
+            rss: bytes_to_mib(mem.rss),
+            vms: bytes_to_mib(mem.vms),
+            uss: mem.uss.map(bytes_to_mib),
+            pss: mem.pss.map(bytes_to_mib),
+            io_in: cum.io_in.map(bytes_to_mib),
+            io_out: cum.io_out.map(bytes_to_mib),
+            cpu_time: cum.cpu_time,
+            n_procs: snapshots.len(),
+        })
     }
 
     /// Materialize the running aggregate into a [`BenchmarkRecord`] given the
     /// final wall-clock running time.
     #[must_use]
     pub fn into_record(self, running_time_seconds: f64) -> BenchmarkRecord {
-        let mib = |b: u64| (b as f64) / (1024.0 * 1024.0);
-
         if !self.data_collected {
             return BenchmarkRecord {
                 running_time: running_time_seconds,
@@ -129,54 +217,41 @@ impl SamplerState {
                 ..Default::default()
             };
         }
-
-        let mut io_in_bytes: u64 = 0;
-        let mut io_out_bytes: u64 = 0;
-        let mut cpu_time_seconds = 0.0_f64;
-        let mut any_io = false;
-        for accum in self.per_pid.values() {
-            if let Some(v) = accum.io_read_bytes {
-                io_in_bytes = io_in_bytes.saturating_add(v);
-                any_io = true;
-            }
-            if let Some(v) = accum.io_write_bytes {
-                io_out_bytes = io_out_bytes.saturating_add(v);
-                any_io = true;
-            }
-            cpu_time_seconds += accum.cpu_time_seconds;
-        }
-
+        let cum = cumulative_totals(&self.per_pid);
         let mean_load = if running_time_seconds > 0.0 {
-            (cpu_time_seconds / running_time_seconds) * 100.0
+            (cum.cpu_time / running_time_seconds) * 100.0
         } else {
             0.0
         };
-
         BenchmarkRecord {
             running_time: running_time_seconds,
-            max_rss: Some(mib(self.max_rss_bytes)),
-            max_vms: Some(mib(self.max_vms_bytes)),
-            max_uss: self.max_uss_bytes.map(mib),
-            max_pss: self.max_pss_bytes.map(mib),
-            io_in: if any_io { Some(mib(io_in_bytes)) } else { None },
-            io_out: if any_io { Some(mib(io_out_bytes)) } else { None },
+            max_rss: Some(bytes_to_mib(self.max_rss_bytes)),
+            max_vms: Some(bytes_to_mib(self.max_vms_bytes)),
+            max_uss: self.max_uss_bytes.map(bytes_to_mib),
+            max_pss: self.max_pss_bytes.map(bytes_to_mib),
+            io_in: cum.io_in.map(bytes_to_mib),
+            io_out: cum.io_out.map(bytes_to_mib),
             mean_load,
-            cpu_time: cpu_time_seconds,
+            cpu_time: cum.cpu_time,
             data_collected: true,
         }
     }
 }
 
 /// Options controlling sampler behavior.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct SamplerOptions {
     /// Wall-clock interval between samples.
     pub interval: Duration,
+    /// Optional path to write a per-tick TSV trace to. When `Some`, the sampler
+    /// thread opens this file, writes [`TRACE_TSV_HEADER`], and appends one row
+    /// per non-empty tick. When `None`, no trace file is created.
+    pub trace_path: Option<Box<Path>>,
 }
 
 impl Default for SamplerOptions {
     fn default() -> Self {
-        Self { interval: DEFAULT_INTERVAL }
+        Self { interval: DEFAULT_INTERVAL, trace_path: None }
     }
 }
 
@@ -201,7 +276,15 @@ impl SamplerHandle {
         let started_at = Instant::now();
         let thread = thread::Builder::new()
             .name("tricord-sampler".into())
-            .spawn(move || run_sampler_loop(root_pid, options.interval, &stop_for_thread))
+            .spawn(move || {
+                run_sampler_loop(
+                    root_pid,
+                    options.interval,
+                    options.trace_path.as_deref(),
+                    started_at,
+                    &stop_for_thread,
+                )
+            })
             .expect("failed to spawn sampler thread");
         Self { stop, thread: Some(thread), started_at }
     }
@@ -224,9 +307,16 @@ impl SamplerHandle {
     }
 }
 
-fn run_sampler_loop(root_pid: i32, interval: Duration, stop: &AtomicBool) -> SamplerState {
+fn run_sampler_loop(
+    root_pid: i32,
+    interval: Duration,
+    trace_path: Option<&Path>,
+    started_at: Instant,
+    stop: &AtomicBool,
+) -> SamplerState {
     let mut state = SamplerState::default();
     let mut sampler = platform::new_sampler();
+    let mut trace = trace_path.and_then(open_trace_writer);
     while !stop.load(Ordering::SeqCst) {
         thread::sleep(interval);
         if stop.load(Ordering::SeqCst) {
@@ -236,12 +326,49 @@ fn run_sampler_loop(root_pid: i32, interval: Duration, stop: &AtomicBool) -> Sam
         }
         let snapshots = sampler.sample_tree(root_pid);
         state.absorb(&snapshots);
+        if let Some(writer) = trace.as_mut()
+            && let Some(tick) = state.tick(&snapshots, started_at.elapsed().as_secs_f64())
+        {
+            // Flush per row so a SIGKILL (the OOM-postmortem case the trace
+            // file exists for) doesn't lose buffered ticks.
+            if let Err(err) =
+                writeln!(writer, "{}", tick.to_tsv_row()).and_then(|()| writer.flush())
+            {
+                eprintln!("tricord: failed to write trace row: {err}");
+                trace = None;
+            }
+        }
     }
     state
 }
 
+/// Open the trace TSV at `path` and write the header. Returns `None` after
+/// reporting to stderr if the file can't be opened — a failing diagnostic
+/// file should never fail the benchmarked run.
+fn open_trace_writer(path: &Path) -> Option<BufWriter<File>> {
+    if let Err(err) = format::ensure_parent_dir(path) {
+        eprintln!("tricord: cannot create trace parent for {}: {err}", path.display());
+        return None;
+    }
+    let file = match File::create(path) {
+        Ok(file) => file,
+        Err(err) => {
+            eprintln!("tricord: cannot open trace file {}: {err}", path.display());
+            return None;
+        }
+    };
+    let mut writer = BufWriter::new(file);
+    if let Err(err) = writeln!(writer, "{TRACE_TSV_HEADER}") {
+        eprintln!("tricord: cannot write trace header to {}: {err}", path.display());
+        return None;
+    }
+    Some(writer)
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::record::TRACE_TSV_HEADER;
+
     use super::*;
 
     #[test]
@@ -350,6 +477,153 @@ mod tests {
         assert_eq!(record.io_out, Some(20.0));
         // cpu_time: child A (1.5) + child B (0.5) = 2.0s
         assert!((record.cpu_time - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn tick_summarizes_live_memory_and_cumulative_io_cpu() {
+        let mut state = SamplerState::default();
+        let snaps = &[ProcessSnapshot {
+            pid: 1,
+            rss_bytes: 12 * 1024 * 1024,
+            vms_bytes: 100 * 1024 * 1024,
+            uss_bytes: Some(8 * 1024 * 1024),
+            pss_bytes: Some(9 * 1024 * 1024),
+            io_read_bytes: Some(2 * 1024 * 1024),
+            io_write_bytes: Some(3 * 1024 * 1024),
+            cpu_time_seconds: 0.7,
+        }];
+        state.absorb(snaps);
+        let tick = state.tick(snaps, 1.5).expect("tick");
+        assert!((tick.elapsed - 1.5).abs() < 1e-9);
+        assert!((tick.rss - 12.0).abs() < 1e-9);
+        assert!((tick.vms - 100.0).abs() < 1e-9);
+        assert_eq!(tick.uss, Some(8.0));
+        assert_eq!(tick.pss, Some(9.0));
+        assert_eq!(tick.io_in, Some(2.0));
+        assert_eq!(tick.io_out, Some(3.0));
+        assert!((tick.cpu_time - 0.7).abs() < 1e-9);
+        assert_eq!(tick.n_procs, 1);
+    }
+
+    #[test]
+    fn tick_returns_none_for_empty_snapshots() {
+        let state = SamplerState::default();
+        assert!(state.tick(&[], 1.0).is_none());
+    }
+
+    #[test]
+    fn tick_io_and_cpu_include_exited_children() {
+        let mut state = SamplerState::default();
+        // Tick 1: parent + child both alive with I/O and CPU.
+        state.absorb(&[
+            ProcessSnapshot {
+                pid: 99,
+                rss_bytes: 1,
+                vms_bytes: 1,
+                io_read_bytes: Some(50 * 1024 * 1024),
+                io_write_bytes: Some(10 * 1024 * 1024),
+                cpu_time_seconds: 0.5,
+                ..Default::default()
+            },
+            ProcessSnapshot {
+                pid: 1,
+                rss_bytes: 1,
+                vms_bytes: 1,
+                io_read_bytes: Some(0),
+                io_write_bytes: Some(0),
+                cpu_time_seconds: 0.1,
+                ..Default::default()
+            },
+        ]);
+        // Tick 2: child (pid 99) exited; only parent (pid 1) sampled.
+        let snaps = &[ProcessSnapshot {
+            pid: 1,
+            rss_bytes: 2,
+            vms_bytes: 2,
+            io_read_bytes: Some(0),
+            io_write_bytes: Some(0),
+            cpu_time_seconds: 0.2,
+            ..Default::default()
+        }];
+        state.absorb(snaps);
+        let tick = state.tick(snaps, 1.0).expect("tick");
+        // I/O cumulative: pid 99 last seen 50 + pid 1 last seen 0 = 50 MiB.
+        assert_eq!(tick.io_in, Some(50.0));
+        assert_eq!(tick.io_out, Some(10.0));
+        // CPU cumulative: pid 99 last 0.5 + pid 1 last 0.2 = 0.7s.
+        assert!((tick.cpu_time - 0.7).abs() < 1e-9);
+        // Only pid 1 is alive in this tick.
+        assert_eq!(tick.n_procs, 1);
+    }
+
+    #[test]
+    fn sampler_thread_writes_trace_file_when_path_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace.tsv");
+        // Sample our own PID so the platform sampler always returns at least
+        // one snapshot per tick.
+        #[allow(clippy::cast_possible_wrap)]
+        let pid = std::process::id() as i32;
+        let handle = SamplerHandle::spawn(
+            pid,
+            SamplerOptions {
+                interval: Duration::from_millis(50),
+                trace_path: Some(trace.clone().into_boxed_path()),
+            },
+        );
+        // Let several ticks fire.
+        thread::sleep(Duration::from_millis(300));
+        let _ = handle.stop();
+
+        let text = std::fs::read_to_string(&trace).expect("trace file");
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines[0], TRACE_TSV_HEADER, "first line should be the trace header");
+        assert!(lines.len() >= 3, "expected header + multiple data rows, got: {text:?}");
+        let mut last_elapsed = -1.0_f64;
+        for row in &lines[1..] {
+            let cols: Vec<&str> = row.split('\t').collect();
+            assert_eq!(cols.len(), 9, "row has wrong column count: {row:?}");
+            let elapsed: f64 = cols[0].parse().expect("elapsed parses");
+            assert!(elapsed >= last_elapsed, "elapsed should be monotonic: {row:?}");
+            last_elapsed = elapsed;
+        }
+    }
+
+    #[test]
+    fn io_read_only_leaves_io_out_none() {
+        // If a process exposes io_read_bytes but never io_write_bytes (or vice
+        // versa), the absent side must remain None — not silently coerced to
+        // Some(0) just because the other side was observed.
+        let mut state = SamplerState::default();
+        state.absorb(&[ProcessSnapshot {
+            pid: 1,
+            rss_bytes: 1,
+            vms_bytes: 1,
+            io_read_bytes: Some(4 * 1024 * 1024),
+            io_write_bytes: None,
+            cpu_time_seconds: 0.0,
+            ..Default::default()
+        }]);
+        let record = state.into_record(1.0);
+        assert_eq!(record.io_in, Some(4.0));
+        assert!(record.io_out.is_none(), "io_out must be None when never observed");
+    }
+
+    #[test]
+    fn io_write_only_leaves_io_in_none() {
+        let mut state = SamplerState::default();
+        state.absorb(&[ProcessSnapshot {
+            pid: 1,
+            rss_bytes: 1,
+            vms_bytes: 1,
+            io_read_bytes: None,
+            io_write_bytes: Some(8 * 1024 * 1024),
+            cpu_time_seconds: 0.0,
+            ..Default::default()
+        }]);
+        let record = state.into_record(1.0);
+        assert!(record.io_in.is_none(), "io_in must be None when never observed");
+        assert_eq!(record.io_out, Some(8.0));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,16 +12,26 @@ fn binary() -> PathBuf {
     path.join("tricorder")
 }
 
-fn run_bench(out: &std::path::Path, format: &str, command: &[&str]) -> std::process::Output {
+fn run_bench(
+    out: &std::path::Path,
+    format: &str,
+    extra_args: &[&str],
+    command: &[&str],
+) -> std::process::Output {
     // Tighten the sampling interval well below the default 0.5 s so a sub-
     // second workload still yields multiple samples even on a heavily-loaded
     // CI runner. Without this, `sleep 0.6` could land in a single 0.5 s
     // window that the sampler thread misses if it's late waking up — which
     // is what caused `json_output_round_trips_to_object` to flake on
-    // macos-latest.
+    // macos-latest. Callers can override via `extra_args` (clap takes the
+    // last value).
     let mut cmd = Command::new(binary());
     cmd.args(["--interval", "0.1"]);
-    cmd.arg("--out").arg(out).arg("--format").arg(format).arg("--");
+    cmd.arg("--out").arg(out).arg("--format").arg(format);
+    for arg in extra_args {
+        cmd.arg(arg);
+    }
+    cmd.arg("--");
     for piece in command {
         cmd.arg(piece);
     }
@@ -32,7 +42,7 @@ fn run_bench(out: &std::path::Path, format: &str, command: &[&str]) -> std::proc
 fn tsv_output_for_short_lived_command_has_correct_shape() {
     let tmp = tempfile::tempdir().unwrap();
     let out = tmp.path().join("timing.tsv");
-    let result = run_bench(&out, "tsv", &["sh", "-c", "sleep 0.7"]);
+    let result = run_bench(&out, "tsv", &[], &["sh", "-c", "sleep 0.7"]);
     assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
 
     let text = std::fs::read_to_string(&out).expect("read tsv");
@@ -55,7 +65,7 @@ fn tsv_output_for_short_lived_command_has_correct_shape() {
 fn json_output_round_trips_to_object() {
     let tmp = tempfile::tempdir().unwrap();
     let out = tmp.path().join("timing.json");
-    let result = run_bench(&out, "json", &["sh", "-c", "sleep 0.6"]);
+    let result = run_bench(&out, "json", &[], &["sh", "-c", "sleep 0.6"]);
     assert!(result.status.success());
 
     let text = std::fs::read_to_string(&out).unwrap();
@@ -69,7 +79,7 @@ fn json_output_round_trips_to_object() {
 fn nested_output_directory_is_created() {
     let tmp = tempfile::tempdir().unwrap();
     let out = tmp.path().join("does/not/exist/yet/timing.tsv");
-    let result = run_bench(&out, "tsv", &["sh", "-c", "true"]);
+    let result = run_bench(&out, "tsv", &[], &["sh", "-c", "true"]);
     assert!(result.status.success());
     assert!(out.exists());
 }
@@ -78,7 +88,7 @@ fn nested_output_directory_is_created() {
 fn exit_code_is_passed_through() {
     let tmp = tempfile::tempdir().unwrap();
     let out = tmp.path().join("timing.tsv");
-    let result = run_bench(&out, "tsv", &["sh", "-c", "exit 42"]);
+    let result = run_bench(&out, "tsv", &[], &["sh", "-c", "exit 42"]);
     assert_eq!(result.status.code(), Some(42));
     // The benchmark file should still exist even when the child failed.
     assert!(out.exists());
@@ -88,7 +98,7 @@ fn exit_code_is_passed_through() {
 fn instant_exit_yields_na_row() {
     let tmp = tempfile::tempdir().unwrap();
     let out = tmp.path().join("timing.tsv");
-    let result = run_bench(&out, "tsv", &["sh", "-c", "true"]);
+    let result = run_bench(&out, "tsv", &[], &["sh", "-c", "true"]);
     assert!(result.status.success());
 
     let text = std::fs::read_to_string(&out).unwrap();
@@ -100,6 +110,54 @@ fn instant_exit_yields_na_row() {
     assert_eq!(cols.len(), 10);
     let wall: f64 = cols[0].parse().expect("wall time parses");
     assert!(wall >= 0.0);
+}
+
+#[test]
+fn trace_flag_writes_per_tick_tsv() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let trace = tmp.path().join("trace.tsv");
+    let trace_str = trace.to_str().expect("utf8 trace path");
+
+    let result = run_bench(&out, "tsv", &["--trace", trace_str], &["sh", "-c", "sleep 0.6"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    // Aggregate file is unaffected by --trace.
+    let agg = std::fs::read_to_string(&out).expect("aggregate tsv");
+    assert_eq!(agg.lines().count(), 2, "aggregate should still be header + 1 row");
+
+    let trace_text = std::fs::read_to_string(&trace).expect("trace tsv");
+    let lines: Vec<&str> = trace_text.lines().collect();
+    assert_eq!(
+        lines[0], "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs",
+        "unexpected trace header"
+    );
+    assert!(
+        lines.len() >= 3,
+        "expected header + multiple ticks, got {}: {trace_text:?}",
+        lines.len()
+    );
+
+    let mut last_elapsed = -1.0_f64;
+    for row in &lines[1..] {
+        let cols: Vec<&str> = row.split('\t').collect();
+        assert_eq!(cols.len(), 9, "row has wrong column count: {row:?}");
+        let elapsed: f64 = cols[0].parse().expect("elapsed parses");
+        assert!(elapsed >= last_elapsed, "elapsed should be monotonic");
+        last_elapsed = elapsed;
+    }
+}
+
+#[test]
+fn trace_parent_directory_is_created() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let trace = tmp.path().join("nested/dir/trace.tsv");
+    let trace_str = trace.to_str().expect("utf8 trace path");
+
+    let result = run_bench(&out, "tsv", &["--trace", trace_str], &["sh", "-c", "sleep 0.3"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+    assert!(trace.exists(), "trace file should be created in nested directory");
 }
 
 fn python3_available() -> bool {
@@ -155,17 +213,7 @@ while time.monotonic() < end:
         scratch = scratch.display().to_string(),
     );
 
-    // Tighten the sampling interval so a ~2 s workload still yields a
-    // dozen-plus samples even if the first poll lands late.
-    let result = Command::new(binary())
-        .arg("--out")
-        .arg(&out)
-        .args(["--interval", "0.1"])
-        .args(["--format", "tsv"])
-        .arg("--")
-        .args(["python3", "-c", &workload])
-        .output()
-        .expect("spawn tricorder");
+    let result = run_bench(&out, "tsv", &[], &["python3", "-c", &workload]);
     assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
 
     let text = std::fs::read_to_string(&out).expect("read tsv");


### PR DESCRIPTION
## Summary

- Add `--trace <PATH>` flag that writes a per-tick TSV alongside the existing aggregate `--out` file.
- Each row carries instantaneous summed memory (rss/vms/uss/pss), cumulative I/O and CPU across every PID observed so far (matching the aggregate's exited-child accounting), elapsed time, and live process count.
- The aggregate file is unchanged — Snakemake bit-compatibility is preserved. The trace file uses its own header (`s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs`).

Motivation: the aggregate row collapses an entire run into one number per metric, hiding spikes and giving you nothing to look at after an OOM kill. The trace file makes "did it spike or stay flat?" answerable, and it's opt-in so existing users see no behavior change.

## Implementation notes

- New `TickRecord` + `TRACE_TSV_HEADER` in `record.rs`. Distinct from the aggregate format — this schema is ours, not Snakemake's.
- New `SamplerState::tick()` builds a `TickRecord` from the just-sampled snapshots plus the running per-PID accumulator. Memory is instantaneous (live tree only); I/O and CPU are cumulative across all observed PIDs, including exited children, so the trace columns are monotonically non-decreasing.
- The sampler thread opens the trace file lazily and writes one row per non-empty tick. Mid-run I/O errors are logged and the trace is dropped — a failing diagnostic file never fails the benchmarked run.
- `SamplerOptions` and `RunOptions` both gain `trace_path: Option<Box<Path>>`; defaults are `None`.

## Test plan

- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean (clippy::pedantic)
- [x] `cargo ci-test` — 46 tests pass (was 36 before this PR)
- [x] New unit tests cover `TickRecord` formatting (full data + missing optionals), `SamplerState::tick` (live memory + cumulative I/O after a child exits + empty-snapshots case), `--trace` CLI parsing, and the sampler thread writing/omitting the trace file based on the path option.
- [x] New integration tests verify (1) the `tricorder` binary writes a well-formed trace file with monotonic elapsed times and the aggregate file is unaffected, and (2) parent directories are created when missing.
- [x] Manual smoke test: `tricorder --interval 0.1 --trace /tmp/trace.tsv -- sh -c 'sleep 0.4'` produced 3 trace rows + 1 aggregate row as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--trace <PATH>` flag enabling per-tick trace output as TSV with memory metrics (RSS/VMS/USS/PSS), cumulative I/O, cumulative CPU time, and process count.
  * Parent directories for trace files are automatically created.

* **Documentation**
  * Updated README with the new `--trace` flag documentation and trace schema details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->