### PR TITLE
feat(cli): add --export-markdown for a sidecar Markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ both spreadsheets and pipelines.
 - **Optional per-tick trace** (`--trace <PATH>`) — one TSV row per sample, so
   you can see how memory, I/O, and CPU evolved during the run instead of just
   the final aggregate.
+- **Optional Markdown export** (`--export-markdown <PATH>`) — renders the
+  aggregate record as a two-column Markdown table, ready to paste into PR
+  descriptions, issue comments, and design docs.
 - **Clean shutdown** — forwards `SIGINT` / `SIGTERM` / `SIGHUP` to the
   child's process group so orchestrators can tear runs down without
   leaking children.
@@ -76,6 +79,9 @@ Options:
       --interval <SECONDS>   Sampling interval [default: 0.5]
       --summary              Print one-line summary to stderr after the run
       --trace <PATH>         Also write a per-tick TSV trace to this path
+      --export-markdown <PATH>
+                             Also write a Markdown table of the aggregate
+                             record to this path
   -v, --verbose...           Increase log level (-v, -vv, -vvv)
   -h, --help                 Print help
   -V, --version              Print version
@@ -142,6 +148,30 @@ I/O and CPU are cumulative, so they are monotonically non-decreasing.
 
 Same fields, raw numeric types, `null` for missing.
 
+### Markdown (`--export-markdown <PATH>`)
+
+When `--export-markdown` is given, `tricorder` writes a two-column Markdown
+table of the aggregate record to that path, alongside the primary `--out`
+file. Designed for pasting into PR descriptions, issue comments, and design
+docs — for the per-tick trace, keep using `--trace`.
+
+```markdown
+| metric    |   value |
+|:----------|--------:|
+| s         | 12.3456 |
+| h:m:s     | 0:00:12 |
+| max_rss   |  101.50 |
+| max_vms   | 2048.00 |
+| max_uss   |   95.20 |
+| max_pss   |   96.00 |
+| io_in     |    1.25 |
+| io_out    |    0.50 |
+| mean_load |  175.00 |
+| cpu_time  |   21.60 |
+```
+
+Same column order, value formatting, and `-` / `NA` rules as the TSV.
+
 ## Platform notes
 
 `tricord` runs on **Linux** and **macOS**. The Linux implementation reads
@@ -198,6 +228,7 @@ let options = RunOptions {
     format: OutputFormat::Tsv,
     force_summary: false,
     trace_path: None,
+    markdown_path: None,
 };
 let outcome = run_command("samtools", &["sort".into(), "in.bam".into()], &options).unwrap();
 println!("exit={} cpu_time={:.2}s", outcome.exit_code(), outcome.record.cpu_time);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,13 @@ pub struct Args {
     #[arg(long, value_name = "PATH")]
     pub trace: Option<PathBuf>,
 
+    /// Optional path for an additional Markdown table of the aggregate
+    /// record. Designed for pasting into PR descriptions, issue comments,
+    /// and design docs; written alongside the primary `--out` file. Per-tick
+    /// trace output stays TSV-only — Markdown is for the single-row summary.
+    #[arg(long, value_name = "PATH")]
+    pub export_markdown: Option<PathBuf>,
+
     /// Verbosity (each `-v` raises the log level: warn → info → debug → trace).
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub verbose: u8,
@@ -155,6 +162,26 @@ mod tests {
     fn trace_defaults_to_none() {
         let args = Args::parse_from(["tricorder", "--out", "out.tsv", "--", "true"]);
         assert!(args.trace.is_none());
+    }
+
+    #[test]
+    fn parses_export_markdown_path() {
+        let args = Args::parse_from([
+            "tricorder",
+            "--out",
+            "out.tsv",
+            "--export-markdown",
+            "/tmp/timing.md",
+            "--",
+            "true",
+        ]);
+        assert_eq!(args.export_markdown, Some(PathBuf::from("/tmp/timing.md")));
+    }
+
+    #[test]
+    fn export_markdown_defaults_to_none() {
+        let args = Args::parse_from(["tricorder", "--out", "out.tsv", "--", "true"]);
+        assert!(args.export_markdown.is_none());
     }
 
     #[test]

--- a/src/format.rs
+++ b/src/format.rs
@@ -79,6 +79,23 @@ pub fn write_to<W: Write>(
     }
 }
 
+/// Serialize `record` as a Markdown table to `path`. Creates parent
+/// directories if needed; overwrites existing files.
+///
+/// Lives alongside [`write_to_path`] but takes no `OutputFormat`: Markdown is
+/// a sidecar output (`--export-markdown`) that can be requested alongside the
+/// primary `--out`/`--format` file, not a third value of `--format`.
+///
+/// # Errors
+/// Returns any I/O error from the file system.
+pub fn write_markdown_to_path(record: &BenchmarkRecord, path: &Path) -> io::Result<()> {
+    ensure_parent_dir(path)?;
+    let file = File::create(path)?;
+    let mut writer = BufWriter::new(file);
+    writer.write_all(record.to_markdown_document().as_bytes())?;
+    writer.flush()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -127,5 +144,19 @@ mod tests {
         write_to_path(&sample_record(), &path, OutputFormat::Tsv).unwrap();
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(text.starts_with("s\th:m:s"));
+    }
+
+    #[test]
+    fn write_markdown_to_path_emits_table_and_creates_parents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nested/deeper/timing.md");
+        write_markdown_to_path(&sample_record(), &path).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let mut lines = text.lines();
+        assert!(lines.next().is_some_and(|line| line.starts_with("| metric")));
+        assert!(lines.next().is_some_and(|line| line.starts_with("|:")));
+        // Spot-check one well-known row from the sample record (s = 0.5).
+        assert!(text.contains("| s "), "missing s row in: {text}");
+        assert!(text.ends_with('\n'));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //!     format: OutputFormat::Tsv,
 //!     force_summary: false,
 //!     trace_path: None,
+//!     markdown_path: None,
 //! };
 //! let outcome = run_command("echo", &["hello".to_string()], &options).unwrap();
 //! assert_eq!(outcome.exit_code(), 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn main() -> ExitCode {
         format: args.format.into(),
         force_summary: args.summary,
         trace_path: args.trace.clone().map(PathBuf::into_boxed_path),
+        markdown_path: args.export_markdown.clone().map(PathBuf::into_boxed_path),
     };
 
     match run_command(&command, &command_args, &options) {

--- a/src/record.rs
+++ b/src/record.rs
@@ -147,6 +147,54 @@ impl BenchmarkRecord {
         serde_json::to_string(self)
     }
 
+    /// Render this record as a Markdown table (two columns: `metric | value`).
+    ///
+    /// Uses the same column order and value formatting as `to_tsv_row` and
+    /// `TSV_HEADER`: `%.4f` for `s`, `%.2f` for floats, `-` for missing
+    /// optional values, and `NA` across all resource cells when
+    /// `data_collected == false`. Column widths auto-fit the longest cell so
+    /// the table stays compact in pasted PR/issue output.
+    #[must_use]
+    pub fn to_markdown_document(&self) -> String {
+        let rows = self.markdown_rows();
+        let metric_w = rows.iter().map(|(m, _)| m.len()).max().unwrap_or(0).max("metric".len());
+        let value_w = rows.iter().map(|(_, v)| v.len()).max().unwrap_or(0).max("value".len());
+
+        let mut out = String::with_capacity(256);
+        writeln!(out, "| {:<metric_w$} | {:>value_w$} |", "metric", "value").unwrap();
+        writeln!(out, "|:{}|{}:|", "-".repeat(metric_w + 1), "-".repeat(value_w + 1)).unwrap();
+        for (metric, value) in &rows {
+            writeln!(out, "| {metric:<metric_w$} | {value:>value_w$} |").unwrap();
+        }
+        out
+    }
+
+    /// Build the ordered `(metric_label, value_string)` pairs that drive the
+    /// Markdown table. The list lives here as a single authoritative column
+    /// order for the Markdown formatter; `to_tsv_row` keeps its own
+    /// independent implementation, so both must be updated together when new
+    /// metrics land.
+    fn markdown_rows(&self) -> Vec<(&'static str, String)> {
+        let cell = |value: Option<f64>| {
+            if self.data_collected { format_optional_float(value) } else { "NA".to_string() }
+        };
+        let scalar = |value: f64| {
+            if self.data_collected { format!("{value:.2}") } else { "NA".to_string() }
+        };
+        vec![
+            ("s", format!("{:.4}", self.running_time)),
+            ("h:m:s", format_hms(self.running_time)),
+            ("max_rss", cell(self.max_rss)),
+            ("max_vms", cell(self.max_vms)),
+            ("max_uss", cell(self.max_uss)),
+            ("max_pss", cell(self.max_pss)),
+            ("io_in", cell(self.io_in)),
+            ("io_out", cell(self.io_out)),
+            ("mean_load", scalar(self.mean_load)),
+            ("cpu_time", scalar(self.cpu_time)),
+        ]
+    }
+
     /// Pretty one-line summary suitable for printing to stderr after a run.
     #[must_use]
     pub fn summary_line(&self) -> String {
@@ -321,6 +369,105 @@ mod tests {
             n_procs: 1,
         };
         assert_eq!(tick.to_tsv_row(), "1.0000\t10.00\t20.00\t-\t-\t-\t-\t0.00\t1");
+    }
+
+    #[test]
+    fn markdown_full_data_exact_layout() {
+        let record = BenchmarkRecord {
+            running_time: 12.3456,
+            max_rss: Some(101.5),
+            max_vms: Some(2048.0),
+            max_uss: Some(95.2),
+            max_pss: Some(96.0),
+            io_in: Some(1.25),
+            io_out: Some(0.5),
+            mean_load: 175.0,
+            cpu_time: 21.6,
+            data_collected: true,
+        };
+        // metric_w = 9 (longest is "mean_load"), value_w = 7 (longest is
+        // "12.3456" / "2048.00" / "0:00:12"). Values right-align so numbers
+        // line up visually; metric labels left-align.
+        //
+        // When new metrics land (tracking issue #11 on fg-labs/tricord), this
+        // golden block needs re-recording — both for the new rows and for any
+        // width shift if a new label is longer than `mean_load`.
+        let expected = "\
+| metric    |   value |
+|:----------|--------:|
+| s         | 12.3456 |
+| h:m:s     | 0:00:12 |
+| max_rss   |  101.50 |
+| max_vms   | 2048.00 |
+| max_uss   |   95.20 |
+| max_pss   |   96.00 |
+| io_in     |    1.25 |
+| io_out    |    0.50 |
+| mean_load |  175.00 |
+| cpu_time  |   21.60 |
+";
+        assert_eq!(record.to_markdown_document(), expected);
+    }
+
+    #[test]
+    fn markdown_no_data_uses_na_in_resource_cells() {
+        let record =
+            BenchmarkRecord { running_time: 0.1234, data_collected: false, ..Default::default() };
+        let doc = record.to_markdown_document();
+        // s and h:m:s are always populated; every resource row shows NA.
+        assert!(doc.contains("| s         |  0.1234 |"), "doc was: {doc}");
+        assert!(doc.contains("| h:m:s     | 0:00:00 |"), "doc was: {doc}");
+        for metric in
+            ["max_rss", "max_vms", "max_uss", "max_pss", "io_in", "io_out", "mean_load", "cpu_time"]
+        {
+            let row = doc
+                .lines()
+                .find(|l| l.contains(metric))
+                .unwrap_or_else(|| panic!("no row for {metric}"));
+            assert!(row.ends_with("|      NA |"), "row for {metric}: {row}");
+        }
+    }
+
+    #[test]
+    fn markdown_missing_optionals_render_as_dash() {
+        let record = BenchmarkRecord {
+            running_time: 1.0,
+            max_rss: Some(10.0),
+            max_vms: Some(20.0),
+            max_uss: Some(8.0),
+            max_pss: None,
+            io_in: None,
+            io_out: None,
+            mean_load: 0.0,
+            cpu_time: 0.0,
+            data_collected: true,
+        };
+        let doc = record.to_markdown_document();
+        // Each None value renders as a bare `-`, just like in the TSV.
+        for metric in ["max_pss", "io_in", "io_out"] {
+            let row = doc.lines().find(|l| l.contains(metric)).expect("metric row");
+            assert!(row.contains(" - "), "expected dash in {metric} row: {row}");
+        }
+    }
+
+    #[test]
+    fn markdown_document_starts_with_header_and_alignment_row() {
+        let record =
+            BenchmarkRecord { running_time: 0.5, data_collected: false, ..Default::default() };
+        let doc = record.to_markdown_document();
+        let mut lines = doc.lines();
+        let header = lines.next().expect("header line");
+        let sep = lines.next().expect("separator line");
+        assert!(header.starts_with("| metric"), "header was: {header}");
+        assert!(header.contains("value"), "header was: {header}");
+        // Alignment row: left colon under metric, right colon under value.
+        assert!(sep.starts_with("|:"), "separator was: {sep}");
+        assert!(sep.ends_with(":|"), "separator was: {sep}");
+        // header + alignment row + one data row per TSV column. Derived from
+        // TSV_HEADER so issue #11's metric additions auto-update the count.
+        let expected_rows = 2 + TSV_HEADER.split('\t').count();
+        assert_eq!(doc.lines().count(), expected_rows);
+        assert!(doc.ends_with('\n'));
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -47,6 +47,10 @@ pub struct RunOptions {
     pub force_summary: bool,
     /// Optional path for a per-tick TSV trace. `None` disables the trace.
     pub trace_path: Option<Box<Path>>,
+    /// Optional path for an additional Markdown table of the aggregate
+    /// record (`--export-markdown`). `None` disables it. Written alongside
+    /// `output_path`, not in place of it.
+    pub markdown_path: Option<Box<Path>>,
 }
 
 /// Spawn `command` (with `args`), benchmark its process tree, and write the
@@ -61,6 +65,11 @@ pub struct RunOptions {
 /// output file. Errors from the child itself surface as a non-zero
 /// [`RunOutcome::exit_code`], not as an `Err`.
 pub fn run_command(command: &str, args: &[String], options: &RunOptions) -> io::Result<RunOutcome> {
+    // Reject distinct flags pointing at the same path *before* spawning
+    // anything — otherwise the second writer silently clobbers the first
+    // and the user loses data with no warning.
+    validate_output_paths(options)?;
+
     let mut cmd = Command::new(command);
     cmd.args(args);
     cmd.stdin(Stdio::inherit());
@@ -85,12 +94,53 @@ pub fn run_command(command: &str, args: &[String], options: &RunOptions) -> io::
     drop(signals);
 
     format::write_to_path(&record, &options.output_path, options.format)?;
+    if let Some(path) = options.markdown_path.as_deref() {
+        format::write_markdown_to_path(&record, path)?;
+    }
 
     if options.force_summary || io::stderr().is_terminal() {
         eprintln!("tricorder: {}", record.summary_line());
     }
 
     Ok(RunOutcome { record, status })
+}
+
+/// Reject any pair of output flags (`--out`, `--trace`, `--export-markdown`)
+/// that resolves to the same on-disk path. Distinct flags must produce
+/// distinct files; otherwise the writers race each other and the user
+/// silently loses one of the outputs.
+///
+/// Paths are compared by their `Path` value as supplied — no canonicalization,
+/// so trailing-slash quirks or `./` prefixes still distinguish files that
+/// would otherwise hit the same inode. The check is intentionally
+/// pessimistic: false positives are user-visible and recoverable
+/// (change a flag), false negatives lose data.
+fn validate_output_paths(options: &RunOptions) -> io::Result<()> {
+    let mut configured: Vec<(&'static str, &Path)> = Vec::with_capacity(3);
+    configured.push(("--out", &options.output_path));
+    if let Some(p) = options.trace_path.as_deref() {
+        configured.push(("--trace", p));
+    }
+    if let Some(p) = options.markdown_path.as_deref() {
+        configured.push(("--export-markdown", p));
+    }
+    for i in 0..configured.len() {
+        for j in (i + 1)..configured.len() {
+            let (flag_a, path_a) = configured[i];
+            let (flag_b, path_b) = configured[j];
+            if path_a == path_b {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "{flag_a} and {flag_b} point to the same path ({}); \
+                         each output flag must use a distinct path",
+                        path_a.display(),
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// POSIX-style exit code derivation: child's `code()` if it exited normally,
@@ -121,5 +171,54 @@ mod tests {
     fn exit_code_signal_uses_128_plus_signum() {
         let status = ExitStatus::from_raw(15); // SIGTERM with no core dump
         assert_eq!(exit_code_for(status), 128 + 15);
+    }
+
+    fn options_with(out: &str, trace: Option<&str>, markdown: Option<&str>) -> RunOptions {
+        RunOptions {
+            interval: Duration::from_millis(100),
+            output_path: Path::new(out).into(),
+            format: OutputFormat::Tsv,
+            force_summary: false,
+            trace_path: trace.map(|p| Path::new(p).into()),
+            markdown_path: markdown.map(|p| Path::new(p).into()),
+        }
+    }
+
+    #[test]
+    fn validate_output_paths_accepts_all_distinct() {
+        let opts = options_with("/tmp/a.tsv", Some("/tmp/b.tsv"), Some("/tmp/c.md"));
+        validate_output_paths(&opts).expect("distinct paths are fine");
+    }
+
+    #[test]
+    fn validate_output_paths_accepts_when_sidecars_absent() {
+        let opts = options_with("/tmp/a.tsv", None, None);
+        validate_output_paths(&opts).expect("single path can't collide with itself");
+    }
+
+    #[test]
+    fn validate_output_paths_rejects_out_equals_markdown() {
+        let opts = options_with("/tmp/shared.tsv", None, Some("/tmp/shared.tsv"));
+        let err = validate_output_paths(&opts).expect_err("must reject collision");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        let msg = err.to_string();
+        assert!(msg.contains("--out") && msg.contains("--export-markdown"), "msg: {msg}");
+        assert!(msg.contains("/tmp/shared.tsv"), "msg: {msg}");
+    }
+
+    #[test]
+    fn validate_output_paths_rejects_trace_equals_markdown() {
+        let opts = options_with("/tmp/agg.tsv", Some("/tmp/shared.tsv"), Some("/tmp/shared.tsv"));
+        let err = validate_output_paths(&opts).expect_err("must reject collision");
+        let msg = err.to_string();
+        assert!(msg.contains("--trace") && msg.contains("--export-markdown"), "msg: {msg}");
+    }
+
+    #[test]
+    fn validate_output_paths_rejects_out_equals_trace() {
+        let opts = options_with("/tmp/shared.tsv", Some("/tmp/shared.tsv"), None);
+        let err = validate_output_paths(&opts).expect_err("must reject collision");
+        let msg = err.to_string();
+        assert!(msg.contains("--out") && msg.contains("--trace"), "msg: {msg}");
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -149,6 +149,137 @@ fn trace_flag_writes_per_tick_tsv() {
 }
 
 #[test]
+fn export_markdown_writes_table_alongside_tsv() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let md = tmp.path().join("timing.md");
+    let md_str = md.to_str().expect("utf8 md path");
+
+    let result = run_bench(&out, "tsv", &["--export-markdown", md_str], &["sh", "-c", "sleep 0.4"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    // The primary TSV is unaffected by --export-markdown.
+    let agg = std::fs::read_to_string(&out).expect("aggregate tsv");
+    assert_eq!(agg.lines().count(), 2, "aggregate should still be header + 1 row");
+
+    // Markdown table: header row, alignment row, then exactly 10 data rows
+    // (one per column in TSV_HEADER).
+    let md_text = std::fs::read_to_string(&md).expect("markdown file");
+    let lines: Vec<&str> = md_text.lines().collect();
+    assert_eq!(lines.len(), 12, "expected header + alignment + 10 metric rows: {md_text:?}");
+    assert!(lines[0].starts_with("| metric"), "unexpected header: {}", lines[0]);
+    assert!(lines[1].starts_with("|:") && lines[1].ends_with(":|"), "alignment row: {}", lines[1]);
+    assert!(lines.iter().any(|l| l.contains("| s ")), "no `s` row: {md_text:?}");
+    assert!(lines.iter().any(|l| l.contains("| cpu_time ")), "no `cpu_time` row: {md_text:?}");
+}
+
+#[test]
+fn export_markdown_and_trace_can_be_combined() {
+    // Lock down the "can be combined" contract — every sidecar path is
+    // independent of the others and the primary output.
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let md = tmp.path().join("timing.md");
+    let trace = tmp.path().join("trace.tsv");
+    let result = run_bench(
+        &out,
+        "tsv",
+        &[
+            "--export-markdown",
+            md.to_str().expect("utf8 md path"),
+            "--trace",
+            trace.to_str().expect("utf8 trace path"),
+        ],
+        &["sh", "-c", "sleep 0.4"],
+    );
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+    let md_text = std::fs::read_to_string(&md).expect("markdown file");
+    assert!(md_text.lines().next().is_some_and(|l| l.starts_with("| metric")));
+    let trace_text = std::fs::read_to_string(&trace).expect("trace file");
+    assert!(trace_text.lines().next().is_some_and(|l| l.starts_with("s\trss")));
+    let agg_text = std::fs::read_to_string(&out).expect("agg file");
+    assert_eq!(agg_text.lines().count(), 2, "aggregate should still be header + 1 row");
+}
+
+#[test]
+fn export_markdown_same_path_as_out_is_rejected() {
+    // Pointing two output flags at the same path would silently clobber.
+    // tricorder should refuse before running the child, surfacing both the
+    // conflicting path and the involved flag names.
+    let tmp = tempfile::tempdir().unwrap();
+    let shared = tmp.path().join("clash.tsv");
+    let shared_str = shared.to_str().expect("utf8");
+    let result =
+        run_bench(&shared, "tsv", &["--export-markdown", shared_str], &["sh", "-c", "true"]);
+    assert!(!result.status.success(), "tricorder should refuse colliding paths");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(stderr.contains("--out") && stderr.contains("--export-markdown"), "stderr: {stderr}");
+    assert!(stderr.contains("clash.tsv"), "stderr should name the offending path: {stderr}");
+}
+
+#[test]
+fn export_markdown_same_path_as_trace_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let shared = tmp.path().join("clash.tsv");
+    let shared_str = shared.to_str().expect("utf8");
+    let result = run_bench(
+        &out,
+        "tsv",
+        &["--trace", shared_str, "--export-markdown", shared_str],
+        &["sh", "-c", "true"],
+    );
+    assert!(!result.status.success());
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(stderr.contains("--trace") && stderr.contains("--export-markdown"), "stderr: {stderr}");
+}
+
+#[test]
+fn trace_same_path_as_out_is_rejected() {
+    // Sibling fix: --out and --trace can also silently clobber today;
+    // close that with the same check.
+    let tmp = tempfile::tempdir().unwrap();
+    let shared = tmp.path().join("clash.tsv");
+    let shared_str = shared.to_str().expect("utf8");
+    let result = run_bench(&shared, "tsv", &["--trace", shared_str], &["sh", "-c", "true"]);
+    assert!(!result.status.success());
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(stderr.contains("--out") && stderr.contains("--trace"), "stderr: {stderr}");
+}
+
+#[test]
+fn export_markdown_is_independent_of_primary_format() {
+    // The Markdown sidecar must work with any `--format` value for the
+    // primary `--out` file, not just TSV. Catches accidental coupling.
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.json");
+    let md = tmp.path().join("timing.md");
+    let md_str = md.to_str().expect("utf8 md path");
+
+    let result = run_bench(&out, "json", &["--export-markdown", md_str], &["sh", "-c", "true"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let json_text = std::fs::read_to_string(&out).unwrap();
+    let value: serde_json::Value = serde_json::from_str(json_text.trim()).expect("valid json");
+    assert!(value.is_object(), "primary output should still be JSON: {json_text}");
+
+    let md_text = std::fs::read_to_string(&md).expect("markdown file");
+    assert!(md_text.lines().next().is_some_and(|l| l.starts_with("| metric")));
+}
+
+#[test]
+fn export_markdown_parent_directory_is_created() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let md = tmp.path().join("nested/dir/timing.md");
+    let md_str = md.to_str().expect("utf8 md path");
+
+    let result = run_bench(&out, "tsv", &["--export-markdown", md_str], &["sh", "-c", "true"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+    assert!(md.exists(), "markdown file should be created in nested directory");
+}
+
+#[test]
 fn trace_parent_directory_is_created() {
     let tmp = tempfile::tempdir().unwrap();
     let out = tmp.path().join("timing.tsv");


### PR DESCRIPTION
## Summary

- Adds `--export-markdown <PATH>` to `tricorder`: writes a two-column Markdown table of the aggregate `BenchmarkRecord` to the given path, alongside the existing `--out` / `--format` output. Designed for pasting tricorder results directly into PR descriptions, issue comments, and design docs.
- The formatter reuses the TSV column order and value rules — `%.4f` for `s`, `%.2f` for floats, `-` for missing optional values, and `NA` across every resource cell when `data_collected` is false. Column widths auto-fit the longest cell; the alignment row left-aligns labels and right-aligns values so numbers line up under the value header.
- Per-tick trace stays TSV-only by design: a per-tick Markdown table would be hundreds-to-thousands of rows, which is exactly what you do not want in a PR description. `--export-markdown` and `--trace` are independent and can be combined.

Closes #12.

## Example output

```markdown
| metric    |   value |
|:----------|--------:|
| s         | 12.3456 |
| h:m:s     | 0:00:12 |
| max_rss   |  101.50 |
| max_vms   | 2048.00 |
| max_uss   |   95.20 |
| max_pss   |   96.00 |
| io_in     |    1.25 |
| io_out    |    0.50 |
| mean_load |  175.00 |
| cpu_time  |   21.60 |
```

## Test plan

- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean (no new clippy `pedantic` allowances)
- [x] `cargo ci-test` — 57 tests pass (was 52; +4 record unit tests, +1 format test, +3 integration tests covering "alongside TSV", "alongside JSON", and "nested parent dir creation")
- [x] `cargo test --doc` — doctest in `src/lib.rs` updated to add `markdown_path: None` and still compiles
- [x] Manual sanity: ran `tricorder --out /tmp/td.tsv --export-markdown /tmp/td.md -- sh -c 'sleep 0.3'` and confirmed the rendered table

## Notes for #11 (metrics tracking)

The metric column list and `data_collected == false` handling are centralized in a single `markdown_rows` helper, so adding a column in #11 only requires touching that one list (plus `to_tsv_row`, which keeps its own independent implementation per the existing pattern). The exact-layout golden test will need re-recording when columns shift; a breadcrumb comment in the test points at #11 so the next author isn't surprised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--export-markdown <PATH>` CLI option to export benchmark results as a two-column Markdown table (metric | value), with formatting and missing-value rules matching TSV output. Parent directories are automatically created.

* **Documentation**
  * Updated README and library documentation to document the new Markdown export feature and usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/tricord/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->