### PR TITLE
feat: track page faults; add --snakemake strict-schema mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ both spreadsheets and pipelines.
 
 - **Whole-tree accounting** — follows forked children and aggregates their
   resource usage; an exited child's I/O is still counted.
-- **Two output formats** — Snakemake-compatible TSV by default, one-line
-  JSON (`--format json`) for programmatic consumers.
+- **Two output formats** — TSV (Snakemake-compatible prefix, extended with
+  `tricord`-specific columns by default) or one-line JSON (`--format json`)
+  for programmatic consumers. Pass `--snakemake` to emit the strict 10-column
+  Snakemake schema when downstream tooling pins to it.
 - **Optional one-line summary** to stderr (`--summary`).
 - **Optional per-tick trace** (`--trace <PATH>`) — one TSV row per sample, so
   you can see how memory, I/O, and CPU evolved during the run instead of just
@@ -82,6 +84,8 @@ Options:
       --export-markdown <PATH>
                              Also write a Markdown table of the aggregate
                              record to this path
+      --snakemake            Emit only the original Snakemake aggregate schema
+                             (TSV, JSON, and Markdown). Does not affect --trace.
   -v, --verbose...           Increase log level (-v, -vv, -vvv)
   -h, --help                 Print help
   -V, --version              Print version
@@ -95,9 +99,15 @@ quoting), invoke `bash -c '...'` explicitly.
 
 ### TSV (default)
 
+By default `tricorder` emits a Snakemake-compatible 10-column prefix followed
+by every column it has added on top (`tricord`-extended schema). Pass
+`--snakemake` to drop the additions and produce exactly the original
+Snakemake schema; the prefix's column order and value formatting are
+identical in both modes.
+
 ```text
-s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
-12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60
+s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_page_faults	minor_page_faults
+12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60	42	1234
 ```
 
 | Column | Units | Meaning |
@@ -112,6 +122,8 @@ s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
 | `io_out` | MiB | Total bytes written to disk by the process tree |
 | `mean_load` | percent of one core | Average CPU load over the run (e.g. 175 = 1.75 cores) |
 | `cpu_time` | seconds | Total user + system CPU time across the process tree |
+| `major_page_faults` | integer | Total major page faults (pages brought in from backing store) across the tree. `tricord`-added; omitted under `--snakemake`. |
+| `minor_page_faults` | integer | Total minor page faults across the tree. `tricord`-added; omitted under `--snakemake`. Always `-` on macOS — see [Platform notes](#platform-notes). |
 
 Missing values render as `-`; if the run was too short for any sample to
 succeed, every resource column is `NA`.
@@ -123,10 +135,10 @@ per sampling tick — useful for "did it spike or stay flat?" plots and for
 post-mortem on OOM kills. The aggregate `--out` file is unaffected.
 
 ```text
-s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs
-0.5012	102.30	2048.00	95.20	96.00	1.25	0.50	0.75	3
-1.0027	120.45	2048.00	112.10	113.00	2.50	1.00	1.55	3
-1.5042	101.50	2048.00	95.20	96.00	2.50	1.00	2.40	2
+s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs	major_page_faults	minor_page_faults
+0.5012	102.30	2048.00	95.20	96.00	1.25	0.50	0.75	3	0	850
+1.0027	120.45	2048.00	112.10	113.00	2.50	1.00	1.55	3	2	1200
+1.5042	101.50	2048.00	95.20	96.00	2.50	1.00	2.40	2	0	340
 ```
 
 | Column | Units | Meaning |
@@ -136,17 +148,30 @@ s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs
 | `io_in`, `io_out` | MiB | **Cumulative** bytes read/written across every PID observed so far (including exited children) |
 | `cpu_time` | seconds | Cumulative user + system CPU time across observed PIDs |
 | `n_procs` | integer | Number of live processes in this tick |
+| `major_page_faults`, `minor_page_faults` | integer | Page faults that occurred *during this tick* (per-tick delta, summed across observed PIDs). Minor is always `-` on macOS. |
 
 Memory columns are instantaneous, so they can go up *or down* between rows;
-I/O and CPU are cumulative, so they are monotonically non-decreasing.
+I/O, CPU, and the page-fault deltas describe activity within the tick — they
+can be zero or non-zero per row but won't drop a previously-counted total.
+The trace is `tricord`-native and is **not** affected by `--snakemake`.
 
 ### JSON (`--format json`)
+
+Default (full) mode includes `tricord`-added fields:
+
+```json
+{"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"major_page_faults":42,"minor_page_faults":1234,"data_collected":true}
+```
+
+Under `--snakemake` the `tricord`-added keys are *absent* from the object
+(not set to `null`), so downstream parsers that hard-code the Snakemake key
+set see exactly what they would have seen from `snakemake.benchmark`:
 
 ```json
 {"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"data_collected":true}
 ```
 
-Same fields, raw numeric types, `null` for missing.
+Raw numeric types, `null` for fields that the platform did not expose.
 
 ### Markdown (`--export-markdown <PATH>`)
 
@@ -189,6 +214,8 @@ macOS implementation uses [`libproc`]'s `proc_pidinfo` and `proc_pid_rusage`
 | `max_pss` | `/proc/<pid>/smaps_rollup` (Pss) | mirrors `max_uss` (kernel does not compute PSS — see below) |
 | `io_in`, `io_out` | `/proc/<pid>/io` | `proc_pid_rusage::ri_diskio_*` |
 | `cpu_time` | `/proc/<pid>/stat` (utime + stime) | `proc_taskinfo::pti_total_user + pti_total_system` |
+| `major_page_faults` | `/proc/<pid>/stat` (majflt) | `proc_pid_rusage::ri_pageins` |
+| `minor_page_faults` | `/proc/<pid>/stat` (minflt) | not exposed — column is `-` |
 
 ### macOS PSS approximation
 
@@ -220,6 +247,7 @@ use std::time::Duration;
 use tricord::{
     run::{run_command, RunOptions},
     format::OutputFormat,
+    SchemaMode,
 };
 
 let options = RunOptions {
@@ -229,6 +257,7 @@ let options = RunOptions {
     force_summary: false,
     trace_path: None,
     markdown_path: None,
+    schema_mode: SchemaMode::Full,
 };
 let outcome = run_command("samtools", &["sort".into(), "in.bam".into()], &options).unwrap();
 println!("exit={} cpu_time={:.2}s", outcome.exit_code(), outcome.record.cpu_time);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,6 +49,15 @@ pub struct Args {
     #[arg(long, value_name = "PATH")]
     pub export_markdown: Option<PathBuf>,
 
+    /// Emit only the original Snakemake aggregate schema. By default,
+    /// `tricord` appends extra columns (page faults, …) on top of the 10
+    /// Snakemake columns; `--snakemake` strips those additions from every
+    /// aggregate-record output (TSV, JSON, and Markdown). The per-tick
+    /// `--trace` file is *not* affected — the trace is `tricord`-native and
+    /// always includes every column.
+    #[arg(long)]
+    pub snakemake: bool,
+
     /// Verbosity (each `-v` raises the log level: warn → info → debug → trace).
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub verbose: u8,
@@ -182,6 +191,18 @@ mod tests {
     fn export_markdown_defaults_to_none() {
         let args = Args::parse_from(["tricorder", "--out", "out.tsv", "--", "true"]);
         assert!(args.export_markdown.is_none());
+    }
+
+    #[test]
+    fn snakemake_flag_defaults_to_false() {
+        let args = Args::parse_from(["tricorder", "--out", "out.tsv", "--", "true"]);
+        assert!(!args.snakemake);
+    }
+
+    #[test]
+    fn snakemake_flag_set_to_true() {
+        let args = Args::parse_from(["tricorder", "--out", "out.tsv", "--snakemake", "--", "true"]);
+        assert!(args.snakemake);
     }
 
     #[test]

--- a/src/format.rs
+++ b/src/format.rs
@@ -6,7 +6,7 @@ use std::{
     path::Path,
 };
 
-use crate::record::BenchmarkRecord;
+use crate::record::{BenchmarkRecord, SchemaMode};
 
 /// One of the supported on-disk output formats.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,8 +28,8 @@ impl OutputFormat {
     }
 }
 
-/// Serialize `record` to `path` in the requested format. Creates parent
-/// directories if needed; overwrites existing files.
+/// Serialize `record` to `path` in the requested format and schema mode.
+/// Creates parent directories if needed; overwrites existing files.
 ///
 /// # Errors
 /// Returns any I/O error from the file system or serialization layer.
@@ -37,11 +37,12 @@ pub fn write_to_path(
     record: &BenchmarkRecord,
     path: &Path,
     format: OutputFormat,
+    mode: SchemaMode,
 ) -> io::Result<()> {
     ensure_parent_dir(path)?;
     let file = File::create(path)?;
     let mut writer = BufWriter::new(file);
-    write_to(record, &mut writer, format)?;
+    write_to(record, &mut writer, format, mode)?;
     // Surface flush errors instead of letting BufWriter::drop swallow them.
     writer.flush()
 }
@@ -68,11 +69,12 @@ pub fn write_to<W: Write>(
     record: &BenchmarkRecord,
     writer: &mut W,
     format: OutputFormat,
+    mode: SchemaMode,
 ) -> io::Result<()> {
     match format {
-        OutputFormat::Tsv => writer.write_all(record.to_tsv_document().as_bytes()),
+        OutputFormat::Tsv => writer.write_all(record.to_tsv_document(mode).as_bytes()),
         OutputFormat::Json => {
-            let json = record.to_json().map_err(io::Error::other)?;
+            let json = record.to_json(mode).map_err(io::Error::other)?;
             writer.write_all(json.as_bytes())?;
             writer.write_all(b"\n")
         }
@@ -88,11 +90,15 @@ pub fn write_to<W: Write>(
 ///
 /// # Errors
 /// Returns any I/O error from the file system.
-pub fn write_markdown_to_path(record: &BenchmarkRecord, path: &Path) -> io::Result<()> {
+pub fn write_markdown_to_path(
+    record: &BenchmarkRecord,
+    path: &Path,
+    mode: SchemaMode,
+) -> io::Result<()> {
     ensure_parent_dir(path)?;
     let file = File::create(path)?;
     let mut writer = BufWriter::new(file);
-    writer.write_all(record.to_markdown_document().as_bytes())?;
+    writer.write_all(record.to_markdown_document(mode).as_bytes())?;
     writer.flush()
 }
 
@@ -111,37 +117,66 @@ mod tests {
             io_out: Some(0.25),
             mean_load: 100.0,
             cpu_time: 0.5,
+            major_page_faults: Some(3),
+            minor_page_faults: Some(120),
             data_collected: true,
         }
     }
 
     #[test]
-    fn tsv_writer_emits_header_and_data_row() {
+    fn tsv_writer_full_mode_emits_full_header_and_data_row() {
         let mut buf = Vec::new();
-        write_to(&sample_record(), &mut buf, OutputFormat::Tsv).unwrap();
+        write_to(&sample_record(), &mut buf, OutputFormat::Tsv, SchemaMode::Full).unwrap();
         let text = std::str::from_utf8(&buf).unwrap();
         let lines: Vec<&str> = text.lines().collect();
         assert_eq!(lines.len(), 2);
-        assert!(lines[0].starts_with("s\th:m:s\t"));
+        assert!(lines[0].ends_with("\tmajor_page_faults\tminor_page_faults"));
         assert!(lines[1].starts_with("0.5000\t"));
+        assert!(lines[1].ends_with("\t3\t120"), "data row: {}", lines[1]);
         assert!(text.ends_with('\n'));
     }
 
     #[test]
-    fn json_writer_emits_one_object_per_line() {
+    fn tsv_writer_strict_mode_emits_snakemake_header() {
         let mut buf = Vec::new();
-        write_to(&sample_record(), &mut buf, OutputFormat::Json).unwrap();
+        write_to(&sample_record(), &mut buf, OutputFormat::Tsv, SchemaMode::SnakemakeStrict)
+            .unwrap();
+        let text = std::str::from_utf8(&buf).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines[0], crate::record::TSV_HEADER);
+        // Data row has exactly 10 tab-separated columns.
+        assert_eq!(lines[1].split('\t').count(), 10);
+    }
+
+    #[test]
+    fn json_writer_full_mode_includes_tricord_fields() {
+        let mut buf = Vec::new();
+        write_to(&sample_record(), &mut buf, OutputFormat::Json, SchemaMode::Full).unwrap();
         let text = std::str::from_utf8(&buf).unwrap().trim_end();
         let value: serde_json::Value = serde_json::from_str(text).unwrap();
         assert!(value.is_object());
         assert_eq!(value["data_collected"], true);
+        assert_eq!(value["major_page_faults"], 3);
+        assert_eq!(value["minor_page_faults"], 120);
+    }
+
+    #[test]
+    fn json_writer_strict_mode_omits_tricord_fields() {
+        let mut buf = Vec::new();
+        write_to(&sample_record(), &mut buf, OutputFormat::Json, SchemaMode::SnakemakeStrict)
+            .unwrap();
+        let text = std::str::from_utf8(&buf).unwrap().trim_end();
+        let value: serde_json::Value = serde_json::from_str(text).unwrap();
+        let obj = value.as_object().unwrap();
+        assert!(!obj.contains_key("major_page_faults"));
+        assert!(!obj.contains_key("minor_page_faults"));
     }
 
     #[test]
     fn write_to_path_creates_parent_directories() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("nested/deeper/timing.tsv");
-        write_to_path(&sample_record(), &path, OutputFormat::Tsv).unwrap();
+        write_to_path(&sample_record(), &path, OutputFormat::Tsv, SchemaMode::Full).unwrap();
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(text.starts_with("s\th:m:s"));
     }
@@ -150,13 +185,22 @@ mod tests {
     fn write_markdown_to_path_emits_table_and_creates_parents() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("nested/deeper/timing.md");
-        write_markdown_to_path(&sample_record(), &path).unwrap();
+        write_markdown_to_path(&sample_record(), &path, SchemaMode::Full).unwrap();
         let text = std::fs::read_to_string(&path).unwrap();
         let mut lines = text.lines();
         assert!(lines.next().is_some_and(|line| line.starts_with("| metric")));
         assert!(lines.next().is_some_and(|line| line.starts_with("|:")));
-        // Spot-check one well-known row from the sample record (s = 0.5).
-        assert!(text.contains("| s "), "missing s row in: {text}");
+        // Spot-check the page-fault row added in full mode.
+        assert!(text.contains("major_page_faults"), "missing page-fault row in: {text}");
         assert!(text.ends_with('\n'));
+    }
+
+    #[test]
+    fn write_markdown_to_path_strict_omits_page_faults() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("timing.md");
+        write_markdown_to_path(&sample_record(), &path, SchemaMode::SnakemakeStrict).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(!text.contains("major_page_faults"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //! use tricord::{
 //!     run::{run_command, RunOptions},
 //!     format::OutputFormat,
+//!     SchemaMode,
 //! };
 //!
 //! let options = RunOptions {
@@ -25,6 +26,7 @@
 //!     force_summary: false,
 //!     trace_path: None,
 //!     markdown_path: None,
+//!     schema_mode: SchemaMode::Full,
 //! };
 //! let outcome = run_command("echo", &["hello".to_string()], &options).unwrap();
 //! assert_eq!(outcome.exit_code(), 0);
@@ -53,5 +55,5 @@ pub(crate) mod sampler;
 pub(crate) mod signals;
 
 pub use format::OutputFormat;
-pub use record::{BenchmarkRecord, TSV_HEADER};
+pub use record::{BenchmarkRecord, SchemaMode, TSV_HEADER, TSV_HEADER_FULL, tsv_header};
 pub use run::{RunOptions, RunOutcome, run_command};

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::{path::PathBuf, process::ExitCode};
 
 use clap::Parser;
 use tricord::{
+    SchemaMode,
     cli::Args,
     run::{RunOptions, run_command},
 };
@@ -27,6 +28,7 @@ fn main() -> ExitCode {
         force_summary: args.summary,
         trace_path: args.trace.clone().map(PathBuf::into_boxed_path),
         markdown_path: args.export_markdown.clone().map(PathBuf::into_boxed_path),
+        schema_mode: if args.snakemake { SchemaMode::SnakemakeStrict } else { SchemaMode::Full },
     };
 
     match run_command(&command, &command_args, &options) {

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -78,6 +78,13 @@ fn sample_process(pid: i32, ticks_per_second: f64) -> Option<ProcessSnapshot> {
     let cpu_ticks = stat.utime.saturating_add(stat.stime);
     let cpu_time_seconds = (cpu_ticks as f64) / ticks_per_second;
 
+    // `/proc/<pid>/stat` reports per-process page faults directly. The
+    // `c{min,maj}flt` siblings count exited children — we already track each
+    // PID in our own per-PID accumulator, so using the c-variants would
+    // double-count. `minflt` and `majflt` are u64 in modern procfs.
+    let major_page_faults = Some(stat.majflt);
+    let minor_page_faults = Some(stat.minflt);
+
     Some(ProcessSnapshot {
         pid,
         rss_bytes,
@@ -87,6 +94,8 @@ fn sample_process(pid: i32, ticks_per_second: f64) -> Option<ProcessSnapshot> {
         io_read_bytes,
         io_write_bytes,
         cpu_time_seconds,
+        major_page_faults,
+        minor_page_faults,
     })
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -121,21 +121,28 @@ fn sample_process(pid: i32) -> Option<ProcessSnapshot> {
         mach_time_to_seconds(task.pti_total_user) + mach_time_to_seconds(task.pti_total_system);
 
     let rusage_result: Result<RUsageInfoV4, _> = pidrusage(pid);
-    let (uss_bytes, pss_bytes, io_read_bytes, io_write_bytes) = match rusage_result {
-        Ok(rusage) => {
-            // ri_phys_footprint is Apple's per-task "owned memory that would
-            // be reclaimed on exit" — the closest analog to USS. We populate
-            // both USS and PSS with it; see module docs.
-            let footprint = rusage.ri_phys_footprint;
-            (
-                Some(footprint),
-                Some(footprint),
-                Some(rusage.ri_diskio_bytesread),
-                Some(rusage.ri_diskio_byteswritten),
-            )
-        }
-        Err(_) => (None, None, None, None),
-    };
+    let (uss_bytes, pss_bytes, io_read_bytes, io_write_bytes, major_page_faults) =
+        match rusage_result {
+            Ok(rusage) => {
+                // ri_phys_footprint is Apple's per-task "owned memory that
+                // would be reclaimed on exit" — the closest analog to USS.
+                // We populate both USS and PSS with it; see module docs.
+                let footprint = rusage.ri_phys_footprint;
+                (
+                    Some(footprint),
+                    Some(footprint),
+                    Some(rusage.ri_diskio_bytesread),
+                    Some(rusage.ri_diskio_byteswritten),
+                    // `ri_pageins` is the per-task major page-fault count
+                    // (pages brought in from backing store). The macOS
+                    // `proc_pid_rusage` struct does not expose minor faults,
+                    // so we leave `minor_page_faults` as `None` — the TSV
+                    // and trace render it as `-`.
+                    Some(rusage.ri_pageins),
+                )
+            }
+            Err(_) => (None, None, None, None, None),
+        };
 
     Some(ProcessSnapshot {
         pid,
@@ -146,6 +153,8 @@ fn sample_process(pid: i32) -> Option<ProcessSnapshot> {
         io_read_bytes,
         io_write_bytes,
         cpu_time_seconds,
+        major_page_faults,
+        minor_page_faults: None,
     })
 }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -7,15 +7,52 @@ use std::fmt::Write as _;
 
 use serde::Serialize;
 
-/// Tab-separated header row, identical to Snakemake's.
+/// Tab-separated aggregate header, **identical to Snakemake's**. Selected by
+/// [`SchemaMode::SnakemakeStrict`] — emitted when the user passes
+/// `--snakemake` to opt out of `tricord`-specific column additions.
 pub const TSV_HEADER: &str =
     "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\tio_in\tio_out\tmean_load\tcpu_time";
 
-/// Tab-separated header for the per-tick trace TSV (`--trace`). Distinct from
-/// [`TSV_HEADER`] because the trace records *instantaneous* memory and
-/// *cumulative-so-far* I/O and CPU values; there is no `mean_load` or `h:m:s`
-/// column because those are only meaningful for the whole-run aggregate.
-pub const TRACE_TSV_HEADER: &str = "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs";
+/// Tab-separated aggregate header in full mode: [`TSV_HEADER`] plus every
+/// column `tricord` has added on top of the Snakemake schema. Selected by
+/// [`SchemaMode::Full`] (the default).
+pub const TSV_HEADER_FULL: &str = "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\t\
+                                   io_in\tio_out\tmean_load\tcpu_time\t\
+                                   major_page_faults\tminor_page_faults";
+
+/// Return the appropriate aggregate header for the requested schema mode.
+#[must_use]
+pub fn tsv_header(mode: SchemaMode) -> &'static str {
+    match mode {
+        SchemaMode::Full => TSV_HEADER_FULL,
+        SchemaMode::SnakemakeStrict => TSV_HEADER,
+    }
+}
+
+/// Tab-separated header for the per-tick trace TSV (`--trace`). The trace is
+/// `tricord`-native (not Snakemake-derived) and so is not affected by
+/// [`SchemaMode`] — it always includes every column.
+pub const TRACE_TSV_HEADER: &str = "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\t\
+                                    major_page_faults\tminor_page_faults";
+
+/// Aggregate-output schema selector.
+///
+/// All `BenchmarkRecord` formatters (`to_tsv_*`, `to_json`, `to_markdown_*`)
+/// take a `SchemaMode`. Snakemake-strict mode emits only the original 10-column
+/// schema; full mode emits everything `tricord` collects. The per-tick trace
+/// is unaffected — `SchemaMode` is purely about the aggregate record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SchemaMode {
+    /// Full schema — `tricord`'s superset of the Snakemake columns. The
+    /// default for CLI users and library consumers.
+    #[default]
+    Full,
+    /// Snakemake-strict — only the original 10 columns of
+    /// `snakemake.benchmark.write_benchmark_records(extended_fmt=False)`.
+    /// Selected by `--snakemake` on the CLI; useful when downstream tooling
+    /// pins to the Snakemake schema.
+    SnakemakeStrict,
+}
 
 /// One per-tick row of the trace TSV.
 ///
@@ -44,21 +81,35 @@ pub struct TickRecord {
     pub cpu_time: f64,
     /// Number of live processes in this tick.
     pub n_procs: usize,
+    /// Major page faults that occurred *during this tick*, summed across the
+    /// observed PIDs (delta from the previous observation, not cumulative).
+    /// `None` if no process exposed major-fault counters this tick.
+    pub major_page_faults: Option<u64>,
+    /// Minor page faults that occurred *during this tick*, summed across the
+    /// observed PIDs (delta from the previous observation). `None` if no
+    /// process exposed minor-fault counters this tick — always `None` on
+    /// macOS where the kernel does not expose minor faults via
+    /// `proc_pid_rusage`.
+    pub minor_page_faults: Option<u64>,
 }
 
 impl TickRecord {
     /// Render this tick as a single TSV row using `%.4f` for elapsed time,
     /// `%.2f` for floats, `-` for missing optional values, and a bare integer
-    /// for `n_procs`.
+    /// for `n_procs` and page-fault counts.
     #[must_use]
     pub fn to_tsv_row(&self) -> String {
-        let mut out = String::with_capacity(96);
+        let mut out = String::with_capacity(128);
         write!(out, "{:.4}\t{:.2}\t{:.2}", self.elapsed, self.rss, self.vms).unwrap();
         for value in [self.uss, self.pss, self.io_in, self.io_out] {
             out.push('\t');
             out.push_str(&format_optional_float(value));
         }
         write!(out, "\t{:.2}\t{}", self.cpu_time, self.n_procs).unwrap();
+        for value in [self.major_page_faults, self.minor_page_faults] {
+            out.push('\t');
+            out.push_str(&format_optional_u64(value));
+        }
         out
     }
 }
@@ -92,6 +143,15 @@ pub struct BenchmarkRecord {
     pub mean_load: f64,
     /// Cumulative user + system CPU time across the process tree, in seconds.
     pub cpu_time: f64,
+    /// Total major page faults observed across the process tree (summed
+    /// per-PID maximum, mirroring CPU/I/O aggregation). `None` if no process
+    /// ever exposed major-fault counters.
+    pub major_page_faults: Option<u64>,
+    /// Total minor page faults observed across the process tree (summed
+    /// per-PID maximum). `None` if no process exposed minor-fault counters —
+    /// always `None` on macOS where the kernel does not expose minor faults
+    /// via `proc_pid_rusage`.
+    pub minor_page_faults: Option<u64>,
     /// Whether at least one sample successfully read OS resource counters.
     ///
     /// When `false` the TSV row is rendered with `NA` placeholders for every
@@ -101,16 +161,25 @@ pub struct BenchmarkRecord {
 }
 
 impl BenchmarkRecord {
-    /// Render this record as a single TSV row using Snakemake's column order
-    /// and value formatting (`%.4f` for `s`, `%.2f` for floats, `-` for `None`,
-    /// `NA` across all resource columns when `data_collected == false`).
+    /// Render this record as a single TSV row.
+    ///
+    /// Snakemake's column order and value formatting (`%.4f` for `s`, `%.2f`
+    /// for floats, `-` for `None`, `NA` across all resource columns when
+    /// `data_collected == false`) applies in both modes. In `Full` mode the
+    /// `tricord`-added columns are appended on the right; page-fault counts
+    /// render as bare integers (or `-` when missing, `NA` when no data).
     #[must_use]
-    pub fn to_tsv_row(&self) -> String {
-        let mut out = String::with_capacity(96);
+    pub fn to_tsv_row(&self, mode: SchemaMode) -> String {
+        let mut out = String::with_capacity(128);
         write!(out, "{:.4}\t{}", self.running_time, format_hms(self.running_time)).unwrap();
 
+        let extra_cols = match mode {
+            SchemaMode::Full => 2, // major_page_faults + minor_page_faults
+            SchemaMode::SnakemakeStrict => 0,
+        };
+
         if !self.data_collected {
-            for _ in 0..8 {
+            for _ in 0..(8 + extra_cols) {
                 out.push_str("\tNA");
             }
             return out;
@@ -123,28 +192,43 @@ impl BenchmarkRecord {
             out.push_str(&format_optional_float(value));
         }
         write!(out, "\t{:.2}\t{:.2}", self.mean_load, self.cpu_time).unwrap();
+        if mode == SchemaMode::Full {
+            for value in [self.major_page_faults, self.minor_page_faults] {
+                out.push('\t');
+                out.push_str(&format_optional_u64(value));
+            }
+        }
         out
     }
 
     /// Render this record as a complete TSV document (header + single data row,
-    /// trailing newline).
+    /// trailing newline). The header matches `mode` — strict mode emits
+    /// [`TSV_HEADER`]; full mode emits [`TSV_HEADER_FULL`].
     #[must_use]
-    pub fn to_tsv_document(&self) -> String {
-        let mut out = String::with_capacity(192);
-        out.push_str(TSV_HEADER);
+    pub fn to_tsv_document(&self, mode: SchemaMode) -> String {
+        let mut out = String::with_capacity(256);
+        out.push_str(tsv_header(mode));
         out.push('\n');
-        out.push_str(&self.to_tsv_row());
+        out.push_str(&self.to_tsv_row(mode));
         out.push('\n');
         out
     }
 
     /// Serialize this record as a JSON object string.
     ///
+    /// In `Full` mode every field of the struct is serialized. In
+    /// `SnakemakeStrict` mode only the original 10 Snakemake fields plus
+    /// `data_collected` are emitted; `tricord`-added fields are omitted from
+    /// the object entirely (not set to `null`).
+    ///
     /// # Errors
     /// Returns an error only if `serde_json` itself fails (which should not
     /// happen for this struct).
-    pub fn to_json(&self) -> serde_json::Result<String> {
-        serde_json::to_string(self)
+    pub fn to_json(&self, mode: SchemaMode) -> serde_json::Result<String> {
+        match mode {
+            SchemaMode::Full => serde_json::to_string(self),
+            SchemaMode::SnakemakeStrict => serde_json::to_string(&SnakemakeView::from(self)),
+        }
     }
 
     /// Render this record as a Markdown table (two columns: `metric | value`).
@@ -154,9 +238,12 @@ impl BenchmarkRecord {
     /// optional values, and `NA` across all resource cells when
     /// `data_collected == false`. Column widths auto-fit the longest cell so
     /// the table stays compact in pasted PR/issue output.
+    ///
+    /// In `SnakemakeStrict` mode the `tricord`-added rows are omitted —
+    /// the table holds only the original 10 Snakemake metric rows.
     #[must_use]
-    pub fn to_markdown_document(&self) -> String {
-        let rows = self.markdown_rows();
+    pub fn to_markdown_document(&self, mode: SchemaMode) -> String {
+        let rows = self.markdown_rows(mode);
         let metric_w = rows.iter().map(|(m, _)| m.len()).max().unwrap_or(0).max("metric".len());
         let value_w = rows.iter().map(|(_, v)| v.len()).max().unwrap_or(0).max("value".len());
 
@@ -174,14 +261,17 @@ impl BenchmarkRecord {
     /// order for the Markdown formatter; `to_tsv_row` keeps its own
     /// independent implementation, so both must be updated together when new
     /// metrics land.
-    fn markdown_rows(&self) -> Vec<(&'static str, String)> {
+    fn markdown_rows(&self, mode: SchemaMode) -> Vec<(&'static str, String)> {
         let cell = |value: Option<f64>| {
             if self.data_collected { format_optional_float(value) } else { "NA".to_string() }
         };
         let scalar = |value: f64| {
             if self.data_collected { format!("{value:.2}") } else { "NA".to_string() }
         };
-        vec![
+        let int_cell = |value: Option<u64>| {
+            if self.data_collected { format_optional_u64(value) } else { "NA".to_string() }
+        };
+        let mut rows = vec![
             ("s", format!("{:.4}", self.running_time)),
             ("h:m:s", format_hms(self.running_time)),
             ("max_rss", cell(self.max_rss)),
@@ -192,7 +282,12 @@ impl BenchmarkRecord {
             ("io_out", cell(self.io_out)),
             ("mean_load", scalar(self.mean_load)),
             ("cpu_time", scalar(self.cpu_time)),
-        ]
+        ];
+        if mode == SchemaMode::Full {
+            rows.push(("major_page_faults", int_cell(self.major_page_faults)));
+            rows.push(("minor_page_faults", int_cell(self.minor_page_faults)));
+        }
+        rows
     }
 
     /// Pretty one-line summary suitable for printing to stderr after a run.
@@ -222,6 +317,51 @@ fn format_optional_float(value: Option<f64>) -> String {
     }
 }
 
+/// Render an `Option<u64>` cell — bare integer for `Some`, `-` for `None`.
+/// Used for page-fault columns where decimals would be misleading.
+fn format_optional_u64(value: Option<u64>) -> String {
+    match value {
+        Some(v) => v.to_string(),
+        None => "-".to_string(),
+    }
+}
+
+/// Strict-mode JSON projection — only the fields in the original Snakemake
+/// schema, by borrowed reference so we don't have to copy the record.
+///
+/// Kept in sync by review pressure: every `tricord`-added field on
+/// [`BenchmarkRecord`] must be deliberately *absent* from this struct.
+#[derive(Serialize)]
+struct SnakemakeView<'a> {
+    running_time: f64,
+    max_rss: &'a Option<f64>,
+    max_vms: &'a Option<f64>,
+    max_uss: &'a Option<f64>,
+    max_pss: &'a Option<f64>,
+    io_in: &'a Option<f64>,
+    io_out: &'a Option<f64>,
+    mean_load: f64,
+    cpu_time: f64,
+    data_collected: bool,
+}
+
+impl<'a> From<&'a BenchmarkRecord> for SnakemakeView<'a> {
+    fn from(r: &'a BenchmarkRecord) -> Self {
+        Self {
+            running_time: r.running_time,
+            max_rss: &r.max_rss,
+            max_vms: &r.max_vms,
+            max_uss: &r.max_uss,
+            max_pss: &r.max_pss,
+            io_in: &r.io_in,
+            io_out: &r.io_out,
+            mean_load: r.mean_load,
+            cpu_time: r.cpu_time,
+            data_collected: r.data_collected,
+        }
+    }
+}
+
 /// Format `seconds` as `H:MM:SS` (or `N day(s), H:MM:SS` past 24 hours),
 /// matching Python's `str(datetime.timedelta(seconds=...))` truncated to
 /// integer seconds.
@@ -247,12 +387,45 @@ pub fn format_hms(seconds: f64) -> String {
 mod tests {
     use super::*;
 
+    fn full_record() -> BenchmarkRecord {
+        BenchmarkRecord {
+            running_time: 12.3456,
+            max_rss: Some(101.5),
+            max_vms: Some(2048.0),
+            max_uss: Some(95.2),
+            max_pss: Some(96.0),
+            io_in: Some(1.25),
+            io_out: Some(0.5),
+            mean_load: 175.0,
+            cpu_time: 21.6,
+            major_page_faults: Some(42),
+            minor_page_faults: Some(1234),
+            data_collected: true,
+        }
+    }
+
     #[test]
     fn header_matches_snakemake() {
         assert_eq!(
             TSV_HEADER,
             "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\tio_in\tio_out\tmean_load\tcpu_time"
         );
+    }
+
+    #[test]
+    fn header_full_appends_tricord_columns() {
+        assert!(TSV_HEADER_FULL.starts_with(TSV_HEADER));
+        assert!(TSV_HEADER_FULL.ends_with("\tmajor_page_faults\tminor_page_faults"));
+        // No reordering of the snakemake prefix.
+        let strict_cols: Vec<&str> = TSV_HEADER.split('\t').collect();
+        let full_cols: Vec<&str> = TSV_HEADER_FULL.split('\t').collect();
+        assert_eq!(&full_cols[..strict_cols.len()], &strict_cols[..]);
+    }
+
+    #[test]
+    fn tsv_header_dispatches_on_mode() {
+        assert_eq!(tsv_header(SchemaMode::SnakemakeStrict), TSV_HEADER);
+        assert_eq!(tsv_header(SchemaMode::Full), TSV_HEADER_FULL);
     }
 
     #[test]
@@ -279,29 +452,51 @@ mod tests {
     }
 
     #[test]
-    fn tsv_row_no_data_uses_na_placeholders() {
+    fn tsv_row_no_data_strict_has_10_nas() {
         let record =
             BenchmarkRecord { running_time: 0.1234, data_collected: false, ..Default::default() };
-        assert_eq!(record.to_tsv_row(), "0.1234\t0:00:00\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA");
+        assert_eq!(
+            record.to_tsv_row(SchemaMode::SnakemakeStrict),
+            "0.1234\t0:00:00\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA"
+        );
     }
 
     #[test]
-    fn tsv_row_full_data() {
-        let record = BenchmarkRecord {
-            running_time: 12.3456,
-            max_rss: Some(101.5),
-            max_vms: Some(2048.0),
-            max_uss: Some(95.2),
-            max_pss: Some(96.0),
-            io_in: Some(1.25),
-            io_out: Some(0.5),
-            mean_load: 175.0,
-            cpu_time: 21.6,
-            data_collected: true,
-        };
+    fn tsv_row_no_data_full_has_12_nas() {
+        // Full mode appends one NA per tricord-added column.
+        let record =
+            BenchmarkRecord { running_time: 0.1234, data_collected: false, ..Default::default() };
         assert_eq!(
-            record.to_tsv_row(),
+            record.to_tsv_row(SchemaMode::Full),
+            "0.1234\t0:00:00\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA"
+        );
+    }
+
+    #[test]
+    fn tsv_row_full_mode_appends_page_fault_columns() {
+        assert_eq!(
+            full_record().to_tsv_row(SchemaMode::Full),
+            "12.3456\t0:00:12\t101.50\t2048.00\t95.20\t96.00\t1.25\t0.50\t175.00\t21.60\t42\t1234"
+        );
+    }
+
+    #[test]
+    fn tsv_row_strict_mode_omits_page_fault_columns() {
+        // Same record, snakemake-strict mode: drop the trailing two columns.
+        assert_eq!(
+            full_record().to_tsv_row(SchemaMode::SnakemakeStrict),
             "12.3456\t0:00:12\t101.50\t2048.00\t95.20\t96.00\t1.25\t0.50\t175.00\t21.60"
+        );
+    }
+
+    #[test]
+    fn tsv_row_full_mode_renders_missing_page_faults_as_dash() {
+        let record =
+            BenchmarkRecord { major_page_faults: None, minor_page_faults: None, ..full_record() };
+        assert!(
+            record.to_tsv_row(SchemaMode::Full).ends_with("\t-\t-"),
+            "row was: {}",
+            record.to_tsv_row(SchemaMode::Full),
         );
     }
 
@@ -318,15 +513,19 @@ mod tests {
             mean_load: 0.0,
             cpu_time: 0.0,
             data_collected: true,
+            ..Default::default()
         };
-        assert_eq!(record.to_tsv_row(), "1.0000\t0:00:01\t10.00\t20.00\t8.00\t-\t-\t-\t0.00\t0.00");
+        assert_eq!(
+            record.to_tsv_row(SchemaMode::SnakemakeStrict),
+            "1.0000\t0:00:01\t10.00\t20.00\t8.00\t-\t-\t-\t0.00\t0.00"
+        );
     }
 
     #[test]
-    fn tsv_document_has_header_and_row() {
+    fn tsv_document_strict_uses_snakemake_header() {
         let record =
             BenchmarkRecord { running_time: 0.5, data_collected: false, ..Default::default() };
-        let doc = record.to_tsv_document();
+        let doc = record.to_tsv_document(SchemaMode::SnakemakeStrict);
         let mut lines = doc.lines();
         assert_eq!(lines.next(), Some(TSV_HEADER));
         assert!(lines.next().is_some_and(|line| line.starts_with("0.5000\t")));
@@ -335,8 +534,21 @@ mod tests {
     }
 
     #[test]
-    fn trace_header_lists_per_tick_columns() {
-        assert_eq!(TRACE_TSV_HEADER, "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs");
+    fn tsv_document_full_uses_full_header() {
+        let record =
+            BenchmarkRecord { running_time: 0.5, data_collected: false, ..Default::default() };
+        let doc = record.to_tsv_document(SchemaMode::Full);
+        let mut lines = doc.lines();
+        assert_eq!(lines.next(), Some(TSV_HEADER_FULL));
+        assert!(lines.next().is_some_and(|line| line.starts_with("0.5000\t")));
+    }
+
+    #[test]
+    fn trace_header_lists_per_tick_columns_including_page_faults() {
+        assert_eq!(
+            TRACE_TSV_HEADER,
+            "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\tmajor_page_faults\tminor_page_faults"
+        );
     }
 
     #[test]
@@ -351,8 +563,13 @@ mod tests {
             io_out: Some(0.5),
             cpu_time: 0.75,
             n_procs: 3,
+            major_page_faults: Some(2),
+            minor_page_faults: Some(150),
         };
-        assert_eq!(tick.to_tsv_row(), "0.5012\t102.30\t2048.00\t95.20\t96.00\t1.25\t0.50\t0.75\t3");
+        assert_eq!(
+            tick.to_tsv_row(),
+            "0.5012\t102.30\t2048.00\t95.20\t96.00\t1.25\t0.50\t0.75\t3\t2\t150"
+        );
     }
 
     #[test]
@@ -367,64 +584,72 @@ mod tests {
             io_out: None,
             cpu_time: 0.0,
             n_procs: 1,
+            major_page_faults: None,
+            minor_page_faults: None,
         };
-        assert_eq!(tick.to_tsv_row(), "1.0000\t10.00\t20.00\t-\t-\t-\t-\t0.00\t1");
+        assert_eq!(tick.to_tsv_row(), "1.0000\t10.00\t20.00\t-\t-\t-\t-\t0.00\t1\t-\t-");
     }
 
     #[test]
     fn markdown_full_data_exact_layout() {
-        let record = BenchmarkRecord {
-            running_time: 12.3456,
-            max_rss: Some(101.5),
-            max_vms: Some(2048.0),
-            max_uss: Some(95.2),
-            max_pss: Some(96.0),
-            io_in: Some(1.25),
-            io_out: Some(0.5),
-            mean_load: 175.0,
-            cpu_time: 21.6,
-            data_collected: true,
-        };
-        // metric_w = 9 (longest is "mean_load"), value_w = 7 (longest is
-        // "12.3456" / "2048.00" / "0:00:12"). Values right-align so numbers
-        // line up visually; metric labels left-align.
+        // Widest label is now "major_page_faults" (17 chars), driving the
+        // metric column width. Value widths are unchanged from before.
         //
         // When new metrics land (tracking issue #11 on fg-labs/tricord), this
         // golden block needs re-recording — both for the new rows and for any
-        // width shift if a new label is longer than `mean_load`.
+        // width shift if a new label is longer.
         let expected = "\
-| metric    |   value |
-|:----------|--------:|
-| s         | 12.3456 |
-| h:m:s     | 0:00:12 |
-| max_rss   |  101.50 |
-| max_vms   | 2048.00 |
-| max_uss   |   95.20 |
-| max_pss   |   96.00 |
-| io_in     |    1.25 |
-| io_out    |    0.50 |
-| mean_load |  175.00 |
-| cpu_time  |   21.60 |
+| metric            |   value |
+|:------------------|--------:|
+| s                 | 12.3456 |
+| h:m:s             | 0:00:12 |
+| max_rss           |  101.50 |
+| max_vms           | 2048.00 |
+| max_uss           |   95.20 |
+| max_pss           |   96.00 |
+| io_in             |    1.25 |
+| io_out            |    0.50 |
+| mean_load         |  175.00 |
+| cpu_time          |   21.60 |
+| major_page_faults |      42 |
+| minor_page_faults |    1234 |
 ";
-        assert_eq!(record.to_markdown_document(), expected);
+        assert_eq!(full_record().to_markdown_document(SchemaMode::Full), expected);
+    }
+
+    #[test]
+    fn markdown_strict_mode_drops_tricord_added_rows() {
+        let doc = full_record().to_markdown_document(SchemaMode::SnakemakeStrict);
+        assert!(!doc.contains("major_page_faults"), "strict doc must not list page faults: {doc}");
+        assert!(!doc.contains("minor_page_faults"));
+        // Header + alignment row + 10 metric rows.
+        assert_eq!(doc.lines().count(), 12);
     }
 
     #[test]
     fn markdown_no_data_uses_na_in_resource_cells() {
         let record =
             BenchmarkRecord { running_time: 0.1234, data_collected: false, ..Default::default() };
-        let doc = record.to_markdown_document();
-        // s and h:m:s are always populated; every resource row shows NA.
-        assert!(doc.contains("| s         |  0.1234 |"), "doc was: {doc}");
-        assert!(doc.contains("| h:m:s     | 0:00:00 |"), "doc was: {doc}");
-        for metric in
-            ["max_rss", "max_vms", "max_uss", "max_pss", "io_in", "io_out", "mean_load", "cpu_time"]
-        {
+        let doc = record.to_markdown_document(SchemaMode::Full);
+        // Strict-prefix metrics: every resource row ends in NA. Page-fault
+        // rows do too, since data_collected gates them.
+        for metric in [
+            "max_rss",
+            "max_vms",
+            "max_uss",
+            "max_pss",
+            "io_in",
+            "io_out",
+            "mean_load",
+            "cpu_time",
+            "major_page_faults",
+            "minor_page_faults",
+        ] {
             let row = doc
                 .lines()
                 .find(|l| l.contains(metric))
                 .unwrap_or_else(|| panic!("no row for {metric}"));
-            assert!(row.ends_with("|      NA |"), "row for {metric}: {row}");
+            assert!(row.ends_with("NA |"), "row for {metric}: {row}");
         }
     }
 
@@ -440,50 +665,56 @@ mod tests {
             io_out: None,
             mean_load: 0.0,
             cpu_time: 0.0,
+            major_page_faults: None,
+            minor_page_faults: None,
             data_collected: true,
         };
-        let doc = record.to_markdown_document();
-        // Each None value renders as a bare `-`, just like in the TSV.
-        for metric in ["max_pss", "io_in", "io_out"] {
+        let doc = record.to_markdown_document(SchemaMode::Full);
+        for metric in ["max_pss", "io_in", "io_out", "major_page_faults", "minor_page_faults"] {
             let row = doc.lines().find(|l| l.contains(metric)).expect("metric row");
             assert!(row.contains(" - "), "expected dash in {metric} row: {row}");
         }
     }
 
     #[test]
-    fn markdown_document_starts_with_header_and_alignment_row() {
+    fn markdown_full_row_count_tracks_tsv_header_full() {
         let record =
             BenchmarkRecord { running_time: 0.5, data_collected: false, ..Default::default() };
-        let doc = record.to_markdown_document();
-        let mut lines = doc.lines();
-        let header = lines.next().expect("header line");
-        let sep = lines.next().expect("separator line");
-        assert!(header.starts_with("| metric"), "header was: {header}");
-        assert!(header.contains("value"), "header was: {header}");
-        // Alignment row: left colon under metric, right colon under value.
-        assert!(sep.starts_with("|:"), "separator was: {sep}");
-        assert!(sep.ends_with(":|"), "separator was: {sep}");
-        // header + alignment row + one data row per TSV column. Derived from
-        // TSV_HEADER so issue #11's metric additions auto-update the count.
-        let expected_rows = 2 + TSV_HEADER.split('\t').count();
+        let doc = record.to_markdown_document(SchemaMode::Full);
+        // header + alignment + one data row per column in TSV_HEADER_FULL.
+        let expected_rows = 2 + TSV_HEADER_FULL.split('\t').count();
         assert_eq!(doc.lines().count(), expected_rows);
-        assert!(doc.ends_with('\n'));
     }
 
     #[test]
-    fn json_round_trip_preserves_fields() {
+    fn json_full_mode_preserves_fields() {
         let record = BenchmarkRecord {
             running_time: 1.5,
             max_rss: Some(42.0),
             max_pss: None,
+            major_page_faults: Some(7),
             data_collected: true,
             ..Default::default()
         };
-        let json = record.to_json().unwrap();
+        let json = record.to_json(SchemaMode::Full).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["running_time"], 1.5);
         assert_eq!(v["max_rss"], 42.0);
         assert!(v["max_pss"].is_null());
         assert_eq!(v["data_collected"], true);
+        assert_eq!(v["major_page_faults"], 7);
+        assert!(v["minor_page_faults"].is_null());
+    }
+
+    #[test]
+    fn json_strict_mode_omits_tricord_added_fields() {
+        let json = full_record().to_json(SchemaMode::SnakemakeStrict).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let obj = v.as_object().expect("object");
+        assert!(!obj.contains_key("major_page_faults"), "strict json: {json}");
+        assert!(!obj.contains_key("minor_page_faults"));
+        // 9 snakemake-numeric fields (running_time + 8 metrics) +
+        // data_collected = 10 keys total.
+        assert_eq!(obj.len(), 10, "unexpected key set: {obj:?}");
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -10,7 +10,7 @@ use std::{
 
 use crate::{
     format::{self, OutputFormat},
-    record::BenchmarkRecord,
+    record::{BenchmarkRecord, SchemaMode},
     sampler::{SamplerHandle, SamplerOptions},
     signals::SignalForwarder,
 };
@@ -51,6 +51,10 @@ pub struct RunOptions {
     /// record (`--export-markdown`). `None` disables it. Written alongside
     /// `output_path`, not in place of it.
     pub markdown_path: Option<Box<Path>>,
+    /// Which schema the aggregate-record formatters (TSV, JSON, Markdown)
+    /// should emit. `SnakemakeStrict` strips `tricord`-added columns;
+    /// `Full` (the default) keeps them. The per-tick trace ignores this.
+    pub schema_mode: SchemaMode,
 }
 
 /// Spawn `command` (with `args`), benchmark its process tree, and write the
@@ -93,9 +97,9 @@ pub fn run_command(command: &str, args: &[String], options: &RunOptions) -> io::
     let record = sampler.stop();
     drop(signals);
 
-    format::write_to_path(&record, &options.output_path, options.format)?;
+    format::write_to_path(&record, &options.output_path, options.format, options.schema_mode)?;
     if let Some(path) = options.markdown_path.as_deref() {
-        format::write_markdown_to_path(&record, path)?;
+        format::write_markdown_to_path(&record, path, options.schema_mode)?;
     }
 
     if options.force_summary || io::stderr().is_terminal() {
@@ -181,6 +185,7 @@ mod tests {
             force_summary: false,
             trace_path: trace.map(|p| Path::new(p).into()),
             markdown_path: markdown.map(|p| Path::new(p).into()),
+            schema_mode: SchemaMode::Full,
         }
     }
 

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -38,6 +38,10 @@ pub const DEFAULT_INTERVAL: Duration = Duration::from_millis(500);
 ///
 /// All byte-valued fields are raw bytes (the [`SamplerState`] aggregator
 /// converts to MiB when it produces the final record).
+///
+/// Page-fault counts are cumulative-since-process-birth integers, like the
+/// I/O byte counters; per-tick deltas are computed downstream in
+/// [`SamplerState::tick`].
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ProcessSnapshot {
     pub pid: i32,
@@ -48,6 +52,13 @@ pub struct ProcessSnapshot {
     pub io_read_bytes: Option<u64>,
     pub io_write_bytes: Option<u64>,
     pub cpu_time_seconds: f64,
+    /// Cumulative major page faults for this process. `None` if the platform
+    /// did not expose them this sample.
+    pub major_page_faults: Option<u64>,
+    /// Cumulative minor page faults for this process. `None` if the platform
+    /// did not expose them this sample (always `None` on macOS via
+    /// `proc_pid_rusage`).
+    pub minor_page_faults: Option<u64>,
 }
 
 /// Per-PID accumulator; used to keep the latest seen value of monotonically-
@@ -57,6 +68,10 @@ struct ProcessAccum {
     io_read_bytes: Option<u64>,
     io_write_bytes: Option<u64>,
     cpu_time_seconds: f64,
+    /// Running max of cumulative major page faults (so summing across PIDs
+    /// gives total tree faults, including exited children).
+    major_page_faults: Option<u64>,
+    minor_page_faults: Option<u64>,
 }
 
 /// Running aggregate of all snapshots taken during a benchmark run.
@@ -71,6 +86,11 @@ pub struct SamplerState {
     max_uss_bytes: Option<u64>,
     max_pss_bytes: Option<u64>,
     per_pid: HashMap<i32, ProcessAccum>,
+    /// Per-PID `(major, minor)` page-fault counts at the end of the last
+    /// tick — used to compute per-tick *deltas* for the trace TSV. Distinct
+    /// from `per_pid.major_page_faults` (which holds the running maximum used
+    /// for aggregate totals).
+    prev_page_faults: HashMap<i32, (u64, u64)>,
     data_collected: bool,
 }
 
@@ -84,11 +104,14 @@ struct MemorySums {
 }
 
 /// Cumulative I/O and CPU totals across every PID observed so far. `io_in`
-/// and `io_out` are `None` when no process has ever exposed I/O counters.
+/// and `io_out` are `None` when no process has ever exposed I/O counters;
+/// `major_page_faults` and `minor_page_faults` likewise.
 struct CumulativeTotals {
     io_in: Option<u64>,
     io_out: Option<u64>,
     cpu_time: f64,
+    major_page_faults: Option<u64>,
+    minor_page_faults: Option<u64>,
 }
 
 /// Sum memory across the snapshots in a single tick.
@@ -119,14 +142,18 @@ fn sum_memory(snapshots: &[ProcessSnapshot]) -> MemorySums {
     }
 }
 
-/// Sum the per-PID accumulators for I/O and CPU. Includes PIDs whose
-/// processes have already exited (last-observed value persists).
+/// Sum the per-PID accumulators for I/O, CPU, and page faults. Includes PIDs
+/// whose processes have already exited (last-observed value persists).
 fn cumulative_totals(per_pid: &HashMap<i32, ProcessAccum>) -> CumulativeTotals {
     let mut io_in: u64 = 0;
     let mut io_out: u64 = 0;
     let mut any_io_in = false;
     let mut any_io_out = false;
     let mut cpu_time = 0.0_f64;
+    let mut major_pf: u64 = 0;
+    let mut minor_pf: u64 = 0;
+    let mut any_major_pf = false;
+    let mut any_minor_pf = false;
     for accum in per_pid.values() {
         if let Some(v) = accum.io_read_bytes {
             io_in = io_in.saturating_add(v);
@@ -137,11 +164,21 @@ fn cumulative_totals(per_pid: &HashMap<i32, ProcessAccum>) -> CumulativeTotals {
             any_io_out = true;
         }
         cpu_time += accum.cpu_time_seconds;
+        if let Some(v) = accum.major_page_faults {
+            major_pf = major_pf.saturating_add(v);
+            any_major_pf = true;
+        }
+        if let Some(v) = accum.minor_page_faults {
+            minor_pf = minor_pf.saturating_add(v);
+            any_minor_pf = true;
+        }
     }
     CumulativeTotals {
         io_in: if any_io_in { Some(io_in) } else { None },
         io_out: if any_io_out { Some(io_out) } else { None },
         cpu_time,
+        major_page_faults: if any_major_pf { Some(major_pf) } else { None },
+        minor_page_faults: if any_minor_pf { Some(minor_pf) } else { None },
     }
 }
 
@@ -175,6 +212,12 @@ impl SamplerState {
             if snap.cpu_time_seconds > entry.cpu_time_seconds {
                 entry.cpu_time_seconds = snap.cpu_time_seconds;
             }
+            if let Some(v) = snap.major_page_faults {
+                entry.major_page_faults = Some(v.max(entry.major_page_faults.unwrap_or(0)));
+            }
+            if let Some(v) = snap.minor_page_faults {
+                entry.minor_page_faults = Some(v.max(entry.minor_page_faults.unwrap_or(0)));
+            }
         }
         self.data_collected = true;
     }
@@ -185,14 +228,29 @@ impl SamplerState {
     ///
     /// Memory totals are instantaneous (summed across `snapshots`); I/O and
     /// CPU are cumulative across every PID observed so far, including
-    /// children that have already exited.
-    #[must_use]
-    pub fn tick(&self, snapshots: &[ProcessSnapshot], elapsed_seconds: f64) -> Option<TickRecord> {
+    /// children that have already exited. Page-fault columns are *deltas*
+    /// for the current tick — for each PID, the difference between the
+    /// current sample and the previous-tick observation, summed across all
+    /// PIDs in this tick. The first observation of a PID is treated as a
+    /// delta from zero, which is correct for PIDs born after `tricord`
+    /// started (their counters started at zero).
+    ///
+    /// Takes `&mut self` because the per-tick delta requires snapshotting
+    /// the current per-PID values into [`Self::prev_page_faults`] so the
+    /// next tick can compute *its* delta.
+    pub fn tick(
+        &mut self,
+        snapshots: &[ProcessSnapshot],
+        elapsed_seconds: f64,
+    ) -> Option<TickRecord> {
         if snapshots.is_empty() {
             return None;
         }
         let mem = sum_memory(snapshots);
         let cum = cumulative_totals(&self.per_pid);
+
+        let (major_delta, minor_delta) = self.compute_and_advance_page_fault_deltas(snapshots);
+
         Some(TickRecord {
             elapsed: elapsed_seconds,
             rss: bytes_to_mib(mem.rss),
@@ -203,7 +261,51 @@ impl SamplerState {
             io_out: cum.io_out.map(bytes_to_mib),
             cpu_time: cum.cpu_time,
             n_procs: snapshots.len(),
+            major_page_faults: major_delta,
+            minor_page_faults: minor_delta,
         })
+    }
+
+    /// For each PID in `snapshots`, return the delta from the previous-tick
+    /// page-fault count (zero if never seen). Sum the deltas across PIDs and
+    /// update [`Self::prev_page_faults`] for the next call.
+    ///
+    /// `Option::None` is returned for major or minor when no process exposed
+    /// that counter this tick — same convention as the I/O fields, so the
+    /// trace TSV renders `-` rather than `0` and consumers can tell "not
+    /// observed" from "observed as zero."
+    fn compute_and_advance_page_fault_deltas(
+        &mut self,
+        snapshots: &[ProcessSnapshot],
+    ) -> (Option<u64>, Option<u64>) {
+        let mut major_delta: u64 = 0;
+        let mut minor_delta: u64 = 0;
+        let mut any_major = false;
+        let mut any_minor = false;
+        for snap in snapshots {
+            let prev = self.prev_page_faults.get(&snap.pid).copied().unwrap_or((0, 0));
+            if let Some(current) = snap.major_page_faults {
+                major_delta = major_delta.saturating_add(current.saturating_sub(prev.0));
+                any_major = true;
+            }
+            if let Some(current) = snap.minor_page_faults {
+                minor_delta = minor_delta.saturating_add(current.saturating_sub(prev.1));
+                any_minor = true;
+            }
+            // Advance prev to the current values (treat unobserved as 0 to
+            // avoid a phantom positive delta on next observation).
+            self.prev_page_faults.insert(
+                snap.pid,
+                (
+                    snap.major_page_faults.unwrap_or(prev.0),
+                    snap.minor_page_faults.unwrap_or(prev.1),
+                ),
+            );
+        }
+        (
+            if any_major { Some(major_delta) } else { None },
+            if any_minor { Some(minor_delta) } else { None },
+        )
     }
 
     /// Materialize the running aggregate into a [`BenchmarkRecord`] given the
@@ -233,6 +335,8 @@ impl SamplerState {
             io_out: cum.io_out.map(bytes_to_mib),
             mean_load,
             cpu_time: cum.cpu_time,
+            major_page_faults: cum.major_page_faults,
+            minor_page_faults: cum.minor_page_faults,
             data_collected: true,
         }
     }
@@ -392,6 +496,7 @@ mod tests {
             io_read_bytes: Some(1024 * 1024),
             io_write_bytes: Some(2 * 1024 * 1024),
             cpu_time_seconds: 0.5,
+            ..Default::default()
         }]);
         let record = state.into_record(2.0);
         assert!(record.data_collected);
@@ -403,6 +508,9 @@ mod tests {
         assert_eq!(record.io_out, Some(2.0));
         assert!((record.cpu_time - 0.5).abs() < 1e-9);
         assert!((record.mean_load - 25.0).abs() < 1e-9); // 0.5s cpu / 2.0s wall = 25%.
+        // Page faults default to None when the platform never reported them.
+        assert!(record.major_page_faults.is_none());
+        assert!(record.minor_page_faults.is_none());
     }
 
     #[test]
@@ -491,6 +599,7 @@ mod tests {
             io_read_bytes: Some(2 * 1024 * 1024),
             io_write_bytes: Some(3 * 1024 * 1024),
             cpu_time_seconds: 0.7,
+            ..Default::default()
         }];
         state.absorb(snaps);
         let tick = state.tick(snaps, 1.5).expect("tick");
@@ -507,7 +616,7 @@ mod tests {
 
     #[test]
     fn tick_returns_none_for_empty_snapshots() {
-        let state = SamplerState::default();
+        let mut state = SamplerState::default();
         assert!(state.tick(&[], 1.0).is_none());
     }
 
@@ -582,7 +691,8 @@ mod tests {
         let mut last_elapsed = -1.0_f64;
         for row in &lines[1..] {
             let cols: Vec<&str> = row.split('\t').collect();
-            assert_eq!(cols.len(), 9, "row has wrong column count: {row:?}");
+            // 9 original trace columns + 2 page-fault delta columns.
+            assert_eq!(cols.len(), 11, "row has wrong column count: {row:?}");
             let elapsed: f64 = cols[0].parse().expect("elapsed parses");
             assert!(elapsed >= last_elapsed, "elapsed should be monotonic: {row:?}");
             last_elapsed = elapsed;
@@ -627,6 +737,124 @@ mod tests {
     }
 
     #[test]
+    fn page_faults_aggregate_sums_per_pid_max_across_tree() {
+        let mut state = SamplerState::default();
+        // Tick 1: child A (100 maj, 5000 min), child B (50 maj, 2000 min).
+        state.absorb(&[
+            ProcessSnapshot {
+                pid: 10,
+                rss_bytes: 1,
+                vms_bytes: 1,
+                major_page_faults: Some(100),
+                minor_page_faults: Some(5000),
+                ..Default::default()
+            },
+            ProcessSnapshot {
+                pid: 11,
+                rss_bytes: 1,
+                vms_bytes: 1,
+                major_page_faults: Some(50),
+                minor_page_faults: Some(2000),
+                ..Default::default()
+            },
+        ]);
+        // Tick 2: B exited; A reached (150, 6500).
+        state.absorb(&[ProcessSnapshot {
+            pid: 10,
+            rss_bytes: 1,
+            vms_bytes: 1,
+            major_page_faults: Some(150),
+            minor_page_faults: Some(6500),
+            ..Default::default()
+        }]);
+        let record = state.into_record(1.0);
+        // Aggregate = sum of per-PID maxima = A(150,6500) + B(50,2000)
+        assert_eq!(record.major_page_faults, Some(200));
+        assert_eq!(record.minor_page_faults, Some(8500));
+    }
+
+    #[test]
+    fn tick_page_faults_are_per_tick_deltas() {
+        let mut state = SamplerState::default();
+        // Tick 1: pid 1 at (10, 100). First observation → delta from 0.
+        let t1 = [ProcessSnapshot {
+            pid: 1,
+            rss_bytes: 1,
+            vms_bytes: 1,
+            major_page_faults: Some(10),
+            minor_page_faults: Some(100),
+            ..Default::default()
+        }];
+        state.absorb(&t1);
+        let tick1 = state.tick(&t1, 0.5).expect("tick1");
+        assert_eq!(tick1.major_page_faults, Some(10));
+        assert_eq!(tick1.minor_page_faults, Some(100));
+
+        // Tick 2: pid 1 at (25, 400). Delta should be (15, 300).
+        let t2 = [ProcessSnapshot {
+            pid: 1,
+            rss_bytes: 1,
+            vms_bytes: 1,
+            major_page_faults: Some(25),
+            minor_page_faults: Some(400),
+            ..Default::default()
+        }];
+        state.absorb(&t2);
+        let tick2 = state.tick(&t2, 1.0).expect("tick2");
+        assert_eq!(tick2.major_page_faults, Some(15));
+        assert_eq!(tick2.minor_page_faults, Some(300));
+    }
+
+    #[test]
+    fn tick_page_faults_saturate_on_pid_reuse() {
+        // If a PID is reused (process exits, OS reassigns the pid), the new
+        // process starts its counters at 0. saturating_sub prevents a
+        // phantom "negative" delta from becoming a huge u64 wrap-around.
+        let mut state = SamplerState::default();
+        let t1 = [ProcessSnapshot {
+            pid: 7,
+            rss_bytes: 1,
+            vms_bytes: 1,
+            major_page_faults: Some(500),
+            minor_page_faults: Some(10_000),
+            ..Default::default()
+        }];
+        state.absorb(&t1);
+        let _ = state.tick(&t1, 0.5);
+        // Same pid, lower counters (new process under reused pid).
+        let t2 = [ProcessSnapshot {
+            pid: 7,
+            rss_bytes: 1,
+            vms_bytes: 1,
+            major_page_faults: Some(3),
+            minor_page_faults: Some(40),
+            ..Default::default()
+        }];
+        state.absorb(&t2);
+        let tick = state.tick(&t2, 1.0).expect("tick2");
+        // Saturating delta is 0, not 2^64 - 497.
+        assert_eq!(tick.major_page_faults, Some(0));
+        assert_eq!(tick.minor_page_faults, Some(0));
+    }
+
+    #[test]
+    fn tick_page_faults_none_when_no_process_exposes_them() {
+        let mut state = SamplerState::default();
+        let snaps = [ProcessSnapshot {
+            pid: 1,
+            rss_bytes: 1,
+            vms_bytes: 1,
+            major_page_faults: None,
+            minor_page_faults: None,
+            ..Default::default()
+        }];
+        state.absorb(&snaps);
+        let tick = state.tick(&snaps, 0.5).expect("tick");
+        assert!(tick.major_page_faults.is_none());
+        assert!(tick.minor_page_faults.is_none());
+    }
+
+    #[test]
     fn missing_uss_and_io_remain_none_in_record() {
         let mut state = SamplerState::default();
         state.absorb(&[ProcessSnapshot {
@@ -638,6 +866,7 @@ mod tests {
             io_read_bytes: None,
             io_write_bytes: None,
             cpu_time_seconds: 0.0,
+            ..Default::default()
         }]);
         let record = state.into_record(1.0);
         assert!(record.max_uss.is_none());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -48,13 +48,16 @@ fn tsv_output_for_short_lived_command_has_correct_shape() {
     let text = std::fs::read_to_string(&out).expect("read tsv");
     let lines: Vec<&str> = text.lines().collect();
     assert_eq!(lines.len(), 2, "expected header + 1 data row, got: {text:?}");
+    // Default mode (no --snakemake): full schema, 10 Snakemake columns +
+    // 2 tricord-appended columns (page faults).
     assert_eq!(
         lines[0],
-        "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\tio_in\tio_out\tmean_load\tcpu_time"
+        "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\tio_in\tio_out\tmean_load\tcpu_time\t\
+         major_page_faults\tminor_page_faults",
     );
 
     let cols: Vec<&str> = lines[1].split('\t').collect();
-    assert_eq!(cols.len(), 10);
+    assert_eq!(cols.len(), 12);
     let wall: f64 = cols[0].parse().expect("wall time parses");
     assert!(wall >= 0.5, "wall time {wall} should be at least 0.5s");
     assert!(wall < 5.0, "wall time {wall} should be under 5s");
@@ -106,8 +109,8 @@ fn instant_exit_yields_na_row() {
     let cols: Vec<&str> = row.split('\t').collect();
     // Either we caught a sample (numbers) or we didn't (NA placeholders);
     // both are valid for an essentially-instant child. Just verify the row
-    // is well-formed.
-    assert_eq!(cols.len(), 10);
+    // is well-formed against the full-mode schema (12 columns).
+    assert_eq!(cols.len(), 12);
     let wall: f64 = cols[0].parse().expect("wall time parses");
     assert!(wall >= 0.0);
 }
@@ -129,8 +132,10 @@ fn trace_flag_writes_per_tick_tsv() {
     let trace_text = std::fs::read_to_string(&trace).expect("trace tsv");
     let lines: Vec<&str> = trace_text.lines().collect();
     assert_eq!(
-        lines[0], "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs",
-        "unexpected trace header"
+        lines[0],
+        "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\t\
+         major_page_faults\tminor_page_faults",
+        "unexpected trace header",
     );
     assert!(
         lines.len() >= 3,
@@ -141,7 +146,8 @@ fn trace_flag_writes_per_tick_tsv() {
     let mut last_elapsed = -1.0_f64;
     for row in &lines[1..] {
         let cols: Vec<&str> = row.split('\t').collect();
-        assert_eq!(cols.len(), 9, "row has wrong column count: {row:?}");
+        // 9 original trace columns + 2 page-fault delta columns.
+        assert_eq!(cols.len(), 11, "row has wrong column count: {row:?}");
         let elapsed: f64 = cols[0].parse().expect("elapsed parses");
         assert!(elapsed >= last_elapsed, "elapsed should be monotonic");
         last_elapsed = elapsed;
@@ -162,15 +168,19 @@ fn export_markdown_writes_table_alongside_tsv() {
     let agg = std::fs::read_to_string(&out).expect("aggregate tsv");
     assert_eq!(agg.lines().count(), 2, "aggregate should still be header + 1 row");
 
-    // Markdown table: header row, alignment row, then exactly 10 data rows
-    // (one per column in TSV_HEADER).
+    // Markdown table in full mode: header + alignment + one data row per
+    // column in TSV_HEADER_FULL (currently 12 = 10 Snakemake + 2 page faults).
     let md_text = std::fs::read_to_string(&md).expect("markdown file");
     let lines: Vec<&str> = md_text.lines().collect();
-    assert_eq!(lines.len(), 12, "expected header + alignment + 10 metric rows: {md_text:?}");
+    assert_eq!(lines.len(), 14, "expected header + alignment + 12 metric rows: {md_text:?}");
     assert!(lines[0].starts_with("| metric"), "unexpected header: {}", lines[0]);
     assert!(lines[1].starts_with("|:") && lines[1].ends_with(":|"), "alignment row: {}", lines[1]);
     assert!(lines.iter().any(|l| l.contains("| s ")), "no `s` row: {md_text:?}");
     assert!(lines.iter().any(|l| l.contains("| cpu_time ")), "no `cpu_time` row: {md_text:?}");
+    assert!(
+        lines.iter().any(|l| l.contains("| major_page_faults ")),
+        "no page-fault row in full-mode Markdown: {md_text:?}",
+    );
 }
 
 #[test]
@@ -291,6 +301,147 @@ fn trace_parent_directory_is_created() {
     assert!(trace.exists(), "trace file should be created in nested directory");
 }
 
+/// Aggregate TSV picks up two new appended columns (`major_page_faults`,
+/// `minor_page_faults`). A workload that touches a large allocation should
+/// drive at least one of them above zero on Linux (`/proc/<pid>/stat`); on
+/// macOS only `major_page_faults` is populated (from `proc_pid_rusage`).
+#[test]
+fn page_faults_appear_in_aggregate_tsv() {
+    if !python3_available() {
+        assert!(std::env::var_os("CI").is_none(), "python3 not on PATH in CI");
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    // 30 MiB allocation + page touch generates plenty of minor faults
+    // (and on a fresh process, some major faults from text/lib paging).
+    // The trailing sleep guarantees at least one sampling tick fires so
+    // `data_collected` is true and cells render as numbers / `-` rather
+    // than the all-`NA` short-lived-process placeholder row.
+    let workload = "import time\n\
+                    buf = bytearray(30 * 1024 * 1024)\n\
+                    for i in range(0, len(buf), 4096): buf[i] = i & 0xff\n\
+                    time.sleep(0.4)";
+    let result = run_bench(&out, "tsv", &[], &["python3", "-c", workload]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let text = std::fs::read_to_string(&out).expect("aggregate tsv");
+    let header = text.lines().next().expect("header");
+    assert!(header.contains("\tmajor_page_faults\tminor_page_faults"), "header: {header}");
+    let cols: Vec<&str> = text.lines().nth(1).expect("data row").split('\t').collect();
+    assert_eq!(cols.len(), 12, "expected 10 base columns + 2 page-fault columns: {cols:?}");
+
+    // major_page_faults is column index 10; minor is 11.
+    let major = cols[10];
+    let minor = cols[11];
+    // major may legitimately be "0" on a warm-cache run; minor on Linux must
+    // be > 0 after touching 30 MiB across 4 KiB pages. macOS exposes only
+    // major via rusage, so minor is "-" on macOS.
+    #[cfg(target_os = "linux")]
+    {
+        let minor_val: u64 = minor.parse().unwrap_or_else(|_| panic!("minor parses: {minor}"));
+        assert!(minor_val > 100, "linux minor_page_faults {minor_val} should be high");
+        let _ = major.parse::<u64>().expect("major parses on linux");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        assert_eq!(minor, "-", "macos minor_page_faults should be `-`, got: {minor}");
+        let _ = major.parse::<u64>().expect("major parses on macos");
+    }
+}
+
+#[test]
+fn snakemake_strict_mode_strips_page_fault_columns() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let result = run_bench(&out, "tsv", &["--snakemake"], &["sh", "-c", "sleep 0.4"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let text = std::fs::read_to_string(&out).unwrap();
+    let header = text.lines().next().expect("header");
+    assert_eq!(
+        header, "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\tio_in\tio_out\tmean_load\tcpu_time",
+        "snakemake-strict header must be the original 10 columns",
+    );
+    let cols: Vec<&str> = text.lines().nth(1).expect("data row").split('\t').collect();
+    assert_eq!(cols.len(), 10, "strict mode row must have 10 columns: {cols:?}");
+}
+
+#[test]
+fn snakemake_strict_mode_strips_page_faults_from_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.json");
+    let result = run_bench(&out, "json", &["--snakemake"], &["sh", "-c", "sleep 0.4"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let text = std::fs::read_to_string(&out).unwrap();
+    let value: serde_json::Value = serde_json::from_str(text.trim()).expect("valid json");
+    let obj = value.as_object().expect("object");
+    assert!(
+        !obj.contains_key("major_page_faults"),
+        "strict-mode JSON must omit major_page_faults: {value}"
+    );
+    assert!(
+        !obj.contains_key("minor_page_faults"),
+        "strict-mode JSON must omit minor_page_faults: {value}"
+    );
+    assert!(obj.contains_key("running_time"));
+    assert!(obj.contains_key("data_collected"));
+}
+
+#[test]
+fn snakemake_strict_mode_strips_page_faults_from_markdown() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let md = tmp.path().join("timing.md");
+    let md_str = md.to_str().expect("utf8");
+    let result = run_bench(
+        &out,
+        "tsv",
+        &["--snakemake", "--export-markdown", md_str],
+        &["sh", "-c", "sleep 0.4"],
+    );
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let md_text = std::fs::read_to_string(&md).unwrap();
+    assert!(
+        !md_text.contains("major_page_faults"),
+        "strict-mode Markdown must omit major_page_faults: {md_text}"
+    );
+    assert!(
+        !md_text.contains("minor_page_faults"),
+        "strict-mode Markdown must omit minor_page_faults: {md_text}"
+    );
+    // Still has the original 10 rows + header + alignment row.
+    assert_eq!(md_text.lines().count(), 12, "strict Markdown should be 12 lines: {md_text:?}");
+}
+
+#[test]
+fn snakemake_strict_mode_does_not_affect_trace_columns() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let trace = tmp.path().join("trace.tsv");
+    let trace_str = trace.to_str().expect("utf8");
+    let result =
+        run_bench(&out, "tsv", &["--snakemake", "--trace", trace_str], &["sh", "-c", "sleep 0.4"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    // Aggregate TSV is strict (10 cols).
+    let agg_text = std::fs::read_to_string(&out).unwrap();
+    let agg_cols: Vec<&str> = agg_text.lines().nth(1).unwrap().split('\t').collect();
+    assert_eq!(agg_cols.len(), 10);
+
+    // Trace TSV is "ours" — strict mode does not touch it. Header must
+    // include the new page-fault columns.
+    let trace_text = std::fs::read_to_string(&trace).expect("trace");
+    let trace_header = trace_text.lines().next().expect("trace header");
+    assert!(
+        trace_header.contains("major_page_faults"),
+        "trace header must include page faults regardless of --snakemake: {trace_header}",
+    );
+}
+
 fn python3_available() -> bool {
     Command::new("python3").arg("--version").output().is_ok_and(|o| o.status.success())
 }
@@ -351,7 +502,8 @@ while time.monotonic() < end:
     let lines: Vec<&str> = text.lines().collect();
     assert_eq!(lines.len(), 2, "expected header + 1 data row, got: {text:?}");
     let cols: Vec<&str> = lines[1].split('\t').collect();
-    assert_eq!(cols.len(), 10);
+    // Default (full) mode: 10 Snakemake columns + 2 page-fault columns.
+    assert_eq!(cols.len(), 12);
 
     let wall: f64 = cols[0].parse().expect("wall");
     let max_rss: f64 = cols[2].parse().expect("max_rss");


### PR DESCRIPTION
First PR off the metrics-tracking umbrella (#11). Stacks on #13 (\`nh/export-markdown\`) — review/merge that one first, then this rebases onto main cleanly.

## Summary

- Adds **major + minor page-fault tracking** to both the aggregate \`BenchmarkRecord\` and the per-tick \`TickRecord\`. Aggregate is per-PID running max summed across the tree (mirroring CPU/I/O); trace is per-tick delta (per-PID current minus previous-tick observation, summed). \`saturating_sub\` guards against pid reuse.
- Introduces **\`--snakemake\` strict-schema mode** as designed in #11. When set, every aggregate-record formatter — TSV, JSON, Markdown — emits only the original 10-column Snakemake schema. The per-tick \`--trace\` is \`tricord\`-native and unaffected.
- New \`SchemaMode\` enum (\`Full\` default, \`SnakemakeStrict\`) parameterizes every \`BenchmarkRecord\` formatter and is the single decision point shared across TSV, JSON, and Markdown writers.

## Platform coverage

| Metric | Linux | macOS |
|---|---|---|
| \`major_page_faults\` | \`/proc/<pid>/stat\` (\`majflt\`) | \`proc_pid_rusage::ri_pageins\` |
| \`minor_page_faults\` | \`/proc/<pid>/stat\` (\`minflt\`) | not exposed by \`RUsageInfoV4\` — column is \`-\` |

The \`c{min,maj}flt\` siblings (children-on-wait) are intentionally not used on Linux: we already track each PID in our own per-PID accumulator, so using them would double-count.

## JSON strict mode

In \`SnakemakeStrict\` mode the new keys are *absent* from the serialized object, not \`null\` — implemented via a borrowed-projection \`SnakemakeView\` struct that has only the original fields. This matches what downstream tools that pin to Snakemake's key set expect.

## TDD trail

Test order: failing integration tests for the four end-to-end behaviors (page faults populated in TSV; \`--snakemake\` strips them from TSV/JSON/Markdown; trace unaffected by strict mode) → impl in vertical slices → unit tests for record formatters, sampler aggregation, per-tick deltas, and pid-reuse saturation. 22 net new tests (4 integration + 18 unit), 79 total.

## Test plan

- [x] \`cargo ci-fmt\` — clean
- [x] \`cargo ci-lint\` — clean (no new clippy \`pedantic\` allowances)
- [x] \`cargo ci-test\` — 79 tests pass on macOS host (was 57)
- [x] \`cargo test --doc\` — \`lib.rs\` doctest updated for new \`SchemaMode\` field
- [x] Manual: \`target/debug/tricorder --out /tmp/t.tsv -- python3 -c '...allocation+sleep...'\` produces non-zero \`minor_page_faults\` on Linux, only \`major_page_faults\` on macOS, and \`--snakemake\` strips them from all three aggregate formats

## Notes for stacked PRs

The next metric PR (context switches) branches off \`nh/page-faults\` and lands the second \`SchemaMode::Full\`-only column pair. Each subsequent metric PR follows the same shape: append to \`TSV_HEADER_FULL\` / \`TRACE_TSV_HEADER\` / \`markdown_rows\` (full-mode branch only), add fields to \`BenchmarkRecord\` / \`TickRecord\` / \`ProcessSnapshot\` / \`ProcessAccum\`, plumb platform code, integration test covering aggregate + trace + strict-mode strip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--snakemake` flag to output benchmark aggregates using only the original Snakemake schema, excluding extra fields
  * Page fault metrics (major and minor) are now captured and reported in TSV, JSON, and Markdown outputs
  * Per-tick traces now include page fault deltas per sampling interval
  * Platform-specific behavior: macOS reports unavailable minor faults as `-`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/tricord/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->