### PR TITLE
feat: track voluntary + involuntary context switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Snakemake schema; the prefix's column order and value formatting are
 identical in both modes.
 
 ```text
-s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_page_faults	minor_page_faults
-12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60	42	1234
+s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches
+12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60	42	1234	80	7
 ```
 
 | Column | Units | Meaning |
@@ -124,6 +124,8 @@ s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_pa
 | `cpu_time` | seconds | Total user + system CPU time across the process tree |
 | `major_page_faults` | integer | Total major page faults (pages brought in from backing store) across the tree. `tricord`-added; omitted under `--snakemake`. |
 | `minor_page_faults` | integer | Total minor page faults across the tree. `tricord`-added; omitted under `--snakemake`. Always `-` on macOS — see [Platform notes](#platform-notes). |
+| `voluntary_ctx_switches` | integer | Total voluntary context switches across the tree (processes yielding the CPU on their own — typically waiting on I/O or a sleep). `tricord`-added; omitted under `--snakemake`. Always `-` on macOS. |
+| `involuntary_ctx_switches` | integer | Total involuntary context switches across the tree (processes preempted by the scheduler). `tricord`-added; omitted under `--snakemake`. Always `-` on macOS. |
 
 Missing values render as `-`; if the run was too short for any sample to
 succeed, every resource column is `NA`.
@@ -135,10 +137,10 @@ per sampling tick — useful for "did it spike or stay flat?" plots and for
 post-mortem on OOM kills. The aggregate `--out` file is unaffected.
 
 ```text
-s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs	major_page_faults	minor_page_faults
-0.5012	102.30	2048.00	95.20	96.00	1.25	0.50	0.75	3	0	850
-1.0027	120.45	2048.00	112.10	113.00	2.50	1.00	1.55	3	2	1200
-1.5042	101.50	2048.00	95.20	96.00	2.50	1.00	2.40	2	0	340
+s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches
+0.5012	102.30	2048.00	95.20	96.00	1.25	0.50	0.75	3	0	850	12	1
+1.0027	120.45	2048.00	112.10	113.00	2.50	1.00	1.55	3	2	1200	28	3
+1.5042	101.50	2048.00	95.20	96.00	2.50	1.00	2.40	2	0	340	15	0
 ```
 
 | Column | Units | Meaning |
@@ -149,6 +151,7 @@ s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs	major_page_faults	minor_page_fau
 | `cpu_time` | seconds | Cumulative user + system CPU time across observed PIDs |
 | `n_procs` | integer | Number of live processes in this tick |
 | `major_page_faults`, `minor_page_faults` | integer | Page faults that occurred *during this tick* (per-tick delta, summed across observed PIDs). Minor is always `-` on macOS. |
+| `voluntary_ctx_switches`, `involuntary_ctx_switches` | integer | Context switches that occurred *during this tick* (per-tick delta, summed across observed PIDs). Both are always `-` on macOS. |
 
 Memory columns are instantaneous, so they can go up *or down* between rows;
 I/O, CPU, and the page-fault deltas describe activity within the tick — they
@@ -160,7 +163,7 @@ The trace is `tricord`-native and is **not** affected by `--snakemake`.
 Default (full) mode includes `tricord`-added fields:
 
 ```json
-{"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"major_page_faults":42,"minor_page_faults":1234,"data_collected":true}
+{"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"major_page_faults":42,"minor_page_faults":1234,"voluntary_ctx_switches":80,"involuntary_ctx_switches":7,"data_collected":true}
 ```
 
 Under `--snakemake` the `tricord`-added keys are *absent* from the object
@@ -216,6 +219,7 @@ macOS implementation uses [`libproc`]'s `proc_pidinfo` and `proc_pid_rusage`
 | `cpu_time` | `/proc/<pid>/stat` (utime + stime) | `proc_taskinfo::pti_total_user + pti_total_system` |
 | `major_page_faults` | `/proc/<pid>/stat` (majflt) | `proc_pid_rusage::ri_pageins` |
 | `minor_page_faults` | `/proc/<pid>/stat` (minflt) | not exposed — column is `-` |
+| `voluntary_ctx_switches`, `involuntary_ctx_switches` | `/proc/<pid>/status` (`voluntary_ctxt_switches`, `nonvoluntary_ctxt_switches`) | not split by `proc_pid_rusage` — both columns are `-` |
 
 ### macOS PSS approximation
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -119,6 +119,8 @@ mod tests {
             cpu_time: 0.5,
             major_page_faults: Some(3),
             minor_page_faults: Some(120),
+            voluntary_ctx_switches: Some(40),
+            involuntary_ctx_switches: Some(5),
             data_collected: true,
         }
     }
@@ -130,9 +132,11 @@ mod tests {
         let text = std::str::from_utf8(&buf).unwrap();
         let lines: Vec<&str> = text.lines().collect();
         assert_eq!(lines.len(), 2);
-        assert!(lines[0].ends_with("\tmajor_page_faults\tminor_page_faults"));
+        assert!(lines[0].ends_with("\tinvoluntary_ctx_switches"));
+        assert!(lines[0].contains("\tmajor_page_faults\tminor_page_faults\t"));
         assert!(lines[1].starts_with("0.5000\t"));
-        assert!(lines[1].ends_with("\t3\t120"), "data row: {}", lines[1]);
+        // Sample record: major=3, minor=120, voluntary=40, involuntary=5.
+        assert!(lines[1].ends_with("\t3\t120\t40\t5"), "data row: {}", lines[1]);
         assert!(text.ends_with('\n'));
     }
 

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -85,6 +85,12 @@ fn sample_process(pid: i32, ticks_per_second: f64) -> Option<ProcessSnapshot> {
     let major_page_faults = Some(stat.majflt);
     let minor_page_faults = Some(stat.minflt);
 
+    // `/proc/<pid>/status` reports per-process context-switch counts under
+    // `voluntary_ctxt_switches` / `nonvoluntary_ctxt_switches`. We use
+    // "involuntary" as the public name (matches BSD `rusage` terminology).
+    let voluntary_ctx_switches = status.voluntary_ctxt_switches;
+    let involuntary_ctx_switches = status.nonvoluntary_ctxt_switches;
+
     Some(ProcessSnapshot {
         pid,
         rss_bytes,
@@ -96,6 +102,8 @@ fn sample_process(pid: i32, ticks_per_second: f64) -> Option<ProcessSnapshot> {
         cpu_time_seconds,
         major_page_faults,
         minor_page_faults,
+        voluntary_ctx_switches,
+        involuntary_ctx_switches,
     })
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -155,6 +155,13 @@ fn sample_process(pid: i32) -> Option<ProcessSnapshot> {
         cpu_time_seconds,
         major_page_faults,
         minor_page_faults: None,
+        // `RUsageInfoV4` does not split context switches voluntary vs
+        // involuntary, and `proc_taskinfo::pti_csw` is the *total* — using
+        // it under a "voluntary" label would be misleading. Both columns
+        // stay `None` and render as `-`; if a future PR can plumb a more
+        // granular source we can populate them then.
+        voluntary_ctx_switches: None,
+        involuntary_ctx_switches: None,
     })
 }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -18,7 +18,8 @@ pub const TSV_HEADER: &str =
 /// [`SchemaMode::Full`] (the default).
 pub const TSV_HEADER_FULL: &str = "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\t\
                                    io_in\tio_out\tmean_load\tcpu_time\t\
-                                   major_page_faults\tminor_page_faults";
+                                   major_page_faults\tminor_page_faults\t\
+                                   voluntary_ctx_switches\tinvoluntary_ctx_switches";
 
 /// Return the appropriate aggregate header for the requested schema mode.
 #[must_use]
@@ -33,7 +34,8 @@ pub fn tsv_header(mode: SchemaMode) -> &'static str {
 /// `tricord`-native (not Snakemake-derived) and so is not affected by
 /// [`SchemaMode`] — it always includes every column.
 pub const TRACE_TSV_HEADER: &str = "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\t\
-                                    major_page_faults\tminor_page_faults";
+                                    major_page_faults\tminor_page_faults\t\
+                                    voluntary_ctx_switches\tinvoluntary_ctx_switches";
 
 /// Aggregate-output schema selector.
 ///
@@ -91,6 +93,16 @@ pub struct TickRecord {
     /// macOS where the kernel does not expose minor faults via
     /// `proc_pid_rusage`.
     pub minor_page_faults: Option<u64>,
+    /// Voluntary context switches that occurred *during this tick*, summed
+    /// across the observed PIDs (delta from the previous observation).
+    /// `None` if no process exposed counters this tick — always `None` on
+    /// macOS (`proc_pid_rusage` does not split context switches).
+    pub voluntary_ctx_switches: Option<u64>,
+    /// Involuntary context switches that occurred *during this tick*, summed
+    /// across the observed PIDs (delta from the previous observation).
+    /// `None` if no process exposed counters this tick — always `None` on
+    /// macOS.
+    pub involuntary_ctx_switches: Option<u64>,
 }
 
 impl TickRecord {
@@ -106,7 +118,12 @@ impl TickRecord {
             out.push_str(&format_optional_float(value));
         }
         write!(out, "\t{:.2}\t{}", self.cpu_time, self.n_procs).unwrap();
-        for value in [self.major_page_faults, self.minor_page_faults] {
+        for value in [
+            self.major_page_faults,
+            self.minor_page_faults,
+            self.voluntary_ctx_switches,
+            self.involuntary_ctx_switches,
+        ] {
             out.push('\t');
             out.push_str(&format_optional_u64(value));
         }
@@ -152,6 +169,13 @@ pub struct BenchmarkRecord {
     /// always `None` on macOS where the kernel does not expose minor faults
     /// via `proc_pid_rusage`.
     pub minor_page_faults: Option<u64>,
+    /// Total voluntary context switches observed across the process tree
+    /// (summed per-PID maximum). `None` on macOS — `proc_pid_rusage` does
+    /// not split context switches voluntary vs involuntary.
+    pub voluntary_ctx_switches: Option<u64>,
+    /// Total involuntary context switches observed across the process tree
+    /// (summed per-PID maximum). `None` on macOS.
+    pub involuntary_ctx_switches: Option<u64>,
     /// Whether at least one sample successfully read OS resource counters.
     ///
     /// When `false` the TSV row is rendered with `NA` placeholders for every
@@ -174,7 +198,8 @@ impl BenchmarkRecord {
         write!(out, "{:.4}\t{}", self.running_time, format_hms(self.running_time)).unwrap();
 
         let extra_cols = match mode {
-            SchemaMode::Full => 2, // major_page_faults + minor_page_faults
+            // page faults (2) + ctx switches (2)
+            SchemaMode::Full => 4,
             SchemaMode::SnakemakeStrict => 0,
         };
 
@@ -193,7 +218,12 @@ impl BenchmarkRecord {
         }
         write!(out, "\t{:.2}\t{:.2}", self.mean_load, self.cpu_time).unwrap();
         if mode == SchemaMode::Full {
-            for value in [self.major_page_faults, self.minor_page_faults] {
+            for value in [
+                self.major_page_faults,
+                self.minor_page_faults,
+                self.voluntary_ctx_switches,
+                self.involuntary_ctx_switches,
+            ] {
                 out.push('\t');
                 out.push_str(&format_optional_u64(value));
             }
@@ -286,6 +316,8 @@ impl BenchmarkRecord {
         if mode == SchemaMode::Full {
             rows.push(("major_page_faults", int_cell(self.major_page_faults)));
             rows.push(("minor_page_faults", int_cell(self.minor_page_faults)));
+            rows.push(("voluntary_ctx_switches", int_cell(self.voluntary_ctx_switches)));
+            rows.push(("involuntary_ctx_switches", int_cell(self.involuntary_ctx_switches)));
         }
         rows
     }
@@ -400,6 +432,8 @@ mod tests {
             cpu_time: 21.6,
             major_page_faults: Some(42),
             minor_page_faults: Some(1234),
+            voluntary_ctx_switches: Some(80),
+            involuntary_ctx_switches: Some(7),
             data_collected: true,
         }
     }
@@ -415,11 +449,20 @@ mod tests {
     #[test]
     fn header_full_appends_tricord_columns() {
         assert!(TSV_HEADER_FULL.starts_with(TSV_HEADER));
-        assert!(TSV_HEADER_FULL.ends_with("\tmajor_page_faults\tminor_page_faults"));
+        assert!(TSV_HEADER_FULL.ends_with("\tinvoluntary_ctx_switches"));
         // No reordering of the snakemake prefix.
         let strict_cols: Vec<&str> = TSV_HEADER.split('\t').collect();
         let full_cols: Vec<&str> = TSV_HEADER_FULL.split('\t').collect();
         assert_eq!(&full_cols[..strict_cols.len()], &strict_cols[..]);
+        // All four tricord-added columns are present.
+        for col in [
+            "major_page_faults",
+            "minor_page_faults",
+            "voluntary_ctx_switches",
+            "involuntary_ctx_switches",
+        ] {
+            assert!(full_cols.contains(&col), "missing {col} in {TSV_HEADER_FULL}");
+        }
     }
 
     #[test]
@@ -462,27 +505,31 @@ mod tests {
     }
 
     #[test]
-    fn tsv_row_no_data_full_has_12_nas() {
-        // Full mode appends one NA per tricord-added column.
+    fn tsv_row_no_data_full_has_one_na_per_full_column() {
+        // Full mode emits one NA per resource column (everything but `s` and
+        // `h:m:s`). Auto-derived from TSV_HEADER_FULL so future appended
+        // columns extend it automatically.
         let record =
             BenchmarkRecord { running_time: 0.1234, data_collected: false, ..Default::default() };
-        assert_eq!(
-            record.to_tsv_row(SchemaMode::Full),
-            "0.1234\t0:00:00\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA"
-        );
+        let total_cols = TSV_HEADER_FULL.split('\t').count();
+        let row = record.to_tsv_row(SchemaMode::Full);
+        assert!(row.starts_with("0.1234\t0:00:00\t"));
+        assert_eq!(row.split('\t').count(), total_cols);
+        assert_eq!(row.split('\t').filter(|c| *c == "NA").count(), total_cols - 2);
     }
 
     #[test]
-    fn tsv_row_full_mode_appends_page_fault_columns() {
+    fn tsv_row_full_mode_appends_all_tricord_columns() {
         assert_eq!(
             full_record().to_tsv_row(SchemaMode::Full),
-            "12.3456\t0:00:12\t101.50\t2048.00\t95.20\t96.00\t1.25\t0.50\t175.00\t21.60\t42\t1234"
+            "12.3456\t0:00:12\t101.50\t2048.00\t95.20\t96.00\t1.25\t0.50\t175.00\t21.60\t\
+             42\t1234\t80\t7",
         );
     }
 
     #[test]
-    fn tsv_row_strict_mode_omits_page_fault_columns() {
-        // Same record, snakemake-strict mode: drop the trailing two columns.
+    fn tsv_row_strict_mode_omits_tricord_columns() {
+        // Same record, snakemake-strict mode: drop every tricord-added column.
         assert_eq!(
             full_record().to_tsv_row(SchemaMode::SnakemakeStrict),
             "12.3456\t0:00:12\t101.50\t2048.00\t95.20\t96.00\t1.25\t0.50\t175.00\t21.60"
@@ -490,11 +537,16 @@ mod tests {
     }
 
     #[test]
-    fn tsv_row_full_mode_renders_missing_page_faults_as_dash() {
-        let record =
-            BenchmarkRecord { major_page_faults: None, minor_page_faults: None, ..full_record() };
+    fn tsv_row_full_mode_renders_missing_tricord_metrics_as_dash() {
+        let record = BenchmarkRecord {
+            major_page_faults: None,
+            minor_page_faults: None,
+            voluntary_ctx_switches: None,
+            involuntary_ctx_switches: None,
+            ..full_record()
+        };
         assert!(
-            record.to_tsv_row(SchemaMode::Full).ends_with("\t-\t-"),
+            record.to_tsv_row(SchemaMode::Full).ends_with("\t-\t-\t-\t-"),
             "row was: {}",
             record.to_tsv_row(SchemaMode::Full),
         );
@@ -547,7 +599,9 @@ mod tests {
     fn trace_header_lists_per_tick_columns_including_page_faults() {
         assert_eq!(
             TRACE_TSV_HEADER,
-            "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\tmajor_page_faults\tminor_page_faults"
+            "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\t\
+             major_page_faults\tminor_page_faults\t\
+             voluntary_ctx_switches\tinvoluntary_ctx_switches"
         );
     }
 
@@ -565,10 +619,12 @@ mod tests {
             n_procs: 3,
             major_page_faults: Some(2),
             minor_page_faults: Some(150),
+            voluntary_ctx_switches: Some(11),
+            involuntary_ctx_switches: Some(3),
         };
         assert_eq!(
             tick.to_tsv_row(),
-            "0.5012\t102.30\t2048.00\t95.20\t96.00\t1.25\t0.50\t0.75\t3\t2\t150"
+            "0.5012\t102.30\t2048.00\t95.20\t96.00\t1.25\t0.50\t0.75\t3\t2\t150\t11\t3"
         );
     }
 
@@ -586,33 +642,38 @@ mod tests {
             n_procs: 1,
             major_page_faults: None,
             minor_page_faults: None,
+            voluntary_ctx_switches: None,
+            involuntary_ctx_switches: None,
         };
-        assert_eq!(tick.to_tsv_row(), "1.0000\t10.00\t20.00\t-\t-\t-\t-\t0.00\t1\t-\t-");
+        assert_eq!(tick.to_tsv_row(), "1.0000\t10.00\t20.00\t-\t-\t-\t-\t0.00\t1\t-\t-\t-\t-");
     }
 
     #[test]
     fn markdown_full_data_exact_layout() {
-        // Widest label is now "major_page_faults" (17 chars), driving the
-        // metric column width. Value widths are unchanged from before.
+        // Widest label is now "involuntary_ctx_switches" (24 chars), driving
+        // the metric column width. Value widths are still 7 ("12.3456" /
+        // "2048.00" / "0:00:12") — the new int values are shorter.
         //
         // When new metrics land (tracking issue #11 on fg-labs/tricord), this
         // golden block needs re-recording — both for the new rows and for any
         // width shift if a new label is longer.
         let expected = "\
-| metric            |   value |
-|:------------------|--------:|
-| s                 | 12.3456 |
-| h:m:s             | 0:00:12 |
-| max_rss           |  101.50 |
-| max_vms           | 2048.00 |
-| max_uss           |   95.20 |
-| max_pss           |   96.00 |
-| io_in             |    1.25 |
-| io_out            |    0.50 |
-| mean_load         |  175.00 |
-| cpu_time          |   21.60 |
-| major_page_faults |      42 |
-| minor_page_faults |    1234 |
+| metric                   |   value |
+|:-------------------------|--------:|
+| s                        | 12.3456 |
+| h:m:s                    | 0:00:12 |
+| max_rss                  |  101.50 |
+| max_vms                  | 2048.00 |
+| max_uss                  |   95.20 |
+| max_pss                  |   96.00 |
+| io_in                    |    1.25 |
+| io_out                   |    0.50 |
+| mean_load                |  175.00 |
+| cpu_time                 |   21.60 |
+| major_page_faults        |      42 |
+| minor_page_faults        |    1234 |
+| voluntary_ctx_switches   |      80 |
+| involuntary_ctx_switches |       7 |
 ";
         assert_eq!(full_record().to_markdown_document(SchemaMode::Full), expected);
     }
@@ -667,10 +728,20 @@ mod tests {
             cpu_time: 0.0,
             major_page_faults: None,
             minor_page_faults: None,
+            voluntary_ctx_switches: None,
+            involuntary_ctx_switches: None,
             data_collected: true,
         };
         let doc = record.to_markdown_document(SchemaMode::Full);
-        for metric in ["max_pss", "io_in", "io_out", "major_page_faults", "minor_page_faults"] {
+        for metric in [
+            "max_pss",
+            "io_in",
+            "io_out",
+            "major_page_faults",
+            "minor_page_faults",
+            "voluntary_ctx_switches",
+            "involuntary_ctx_switches",
+        ] {
             let row = doc.lines().find(|l| l.contains(metric)).expect("metric row");
             assert!(row.contains(" - "), "expected dash in {metric} row: {row}");
         }

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -59,6 +59,12 @@ pub struct ProcessSnapshot {
     /// did not expose them this sample (always `None` on macOS via
     /// `proc_pid_rusage`).
     pub minor_page_faults: Option<u64>,
+    /// Cumulative voluntary context switches for this process. `None` on
+    /// macOS — `proc_pid_rusage` does not split context switches.
+    pub voluntary_ctx_switches: Option<u64>,
+    /// Cumulative involuntary context switches for this process. `None` on
+    /// macOS.
+    pub involuntary_ctx_switches: Option<u64>,
 }
 
 /// Per-PID accumulator; used to keep the latest seen value of monotonically-
@@ -72,6 +78,8 @@ struct ProcessAccum {
     /// gives total tree faults, including exited children).
     major_page_faults: Option<u64>,
     minor_page_faults: Option<u64>,
+    voluntary_ctx_switches: Option<u64>,
+    involuntary_ctx_switches: Option<u64>,
 }
 
 /// Running aggregate of all snapshots taken during a benchmark run.
@@ -86,12 +94,33 @@ pub struct SamplerState {
     max_uss_bytes: Option<u64>,
     max_pss_bytes: Option<u64>,
     per_pid: HashMap<i32, ProcessAccum>,
-    /// Per-PID `(major, minor)` page-fault counts at the end of the last
-    /// tick — used to compute per-tick *deltas* for the trace TSV. Distinct
-    /// from `per_pid.major_page_faults` (which holds the running maximum used
-    /// for aggregate totals).
-    prev_page_faults: HashMap<i32, (u64, u64)>,
+    /// Per-PID cumulative counters at the end of the last tick — used to
+    /// compute per-tick *deltas* for the trace TSV. Distinct from the
+    /// matching fields on [`ProcessAccum`] (those hold the running maximum
+    /// used for aggregate totals; this is a point-in-time snapshot).
+    prev_cumulative: HashMap<i32, PrevCumulative>,
     data_collected: bool,
+}
+
+/// Per-PID cumulative-counter snapshot used to compute per-tick deltas.
+/// Each `tricord`-added per-tick metric needs a slot here; the type is
+/// `u64` because `saturating_sub` against an `Option<u64>` would be uglier.
+#[derive(Debug, Clone, Copy, Default)]
+struct PrevCumulative {
+    major_page_faults: u64,
+    minor_page_faults: u64,
+    voluntary_ctx_switches: u64,
+    involuntary_ctx_switches: u64,
+}
+
+/// Per-tick deltas of cumulative counters, summed across observed PIDs.
+/// `None` means no process exposed the counter this tick.
+#[derive(Debug, Default)]
+struct PerTickDeltas {
+    major_page_faults: Option<u64>,
+    minor_page_faults: Option<u64>,
+    voluntary_ctx_switches: Option<u64>,
+    involuntary_ctx_switches: Option<u64>,
 }
 
 /// Per-tick memory sums across the live tree. `uss` and `pss` are `None`
@@ -112,6 +141,8 @@ struct CumulativeTotals {
     cpu_time: f64,
     major_page_faults: Option<u64>,
     minor_page_faults: Option<u64>,
+    voluntary_ctx_switches: Option<u64>,
+    involuntary_ctx_switches: Option<u64>,
 }
 
 /// Sum memory across the snapshots in a single tick.
@@ -154,6 +185,10 @@ fn cumulative_totals(per_pid: &HashMap<i32, ProcessAccum>) -> CumulativeTotals {
     let mut minor_pf: u64 = 0;
     let mut any_major_pf = false;
     let mut any_minor_pf = false;
+    let mut vol_cs: u64 = 0;
+    let mut invol_cs: u64 = 0;
+    let mut any_vol_cs = false;
+    let mut any_invol_cs = false;
     for accum in per_pid.values() {
         if let Some(v) = accum.io_read_bytes {
             io_in = io_in.saturating_add(v);
@@ -172,6 +207,14 @@ fn cumulative_totals(per_pid: &HashMap<i32, ProcessAccum>) -> CumulativeTotals {
             minor_pf = minor_pf.saturating_add(v);
             any_minor_pf = true;
         }
+        if let Some(v) = accum.voluntary_ctx_switches {
+            vol_cs = vol_cs.saturating_add(v);
+            any_vol_cs = true;
+        }
+        if let Some(v) = accum.involuntary_ctx_switches {
+            invol_cs = invol_cs.saturating_add(v);
+            any_invol_cs = true;
+        }
     }
     CumulativeTotals {
         io_in: if any_io_in { Some(io_in) } else { None },
@@ -179,6 +222,8 @@ fn cumulative_totals(per_pid: &HashMap<i32, ProcessAccum>) -> CumulativeTotals {
         cpu_time,
         major_page_faults: if any_major_pf { Some(major_pf) } else { None },
         minor_page_faults: if any_minor_pf { Some(minor_pf) } else { None },
+        voluntary_ctx_switches: if any_vol_cs { Some(vol_cs) } else { None },
+        involuntary_ctx_switches: if any_invol_cs { Some(invol_cs) } else { None },
     }
 }
 
@@ -218,6 +263,14 @@ impl SamplerState {
             if let Some(v) = snap.minor_page_faults {
                 entry.minor_page_faults = Some(v.max(entry.minor_page_faults.unwrap_or(0)));
             }
+            if let Some(v) = snap.voluntary_ctx_switches {
+                entry.voluntary_ctx_switches =
+                    Some(v.max(entry.voluntary_ctx_switches.unwrap_or(0)));
+            }
+            if let Some(v) = snap.involuntary_ctx_switches {
+                entry.involuntary_ctx_switches =
+                    Some(v.max(entry.involuntary_ctx_switches.unwrap_or(0)));
+            }
         }
         self.data_collected = true;
     }
@@ -236,7 +289,7 @@ impl SamplerState {
     /// started (their counters started at zero).
     ///
     /// Takes `&mut self` because the per-tick delta requires snapshotting
-    /// the current per-PID values into [`Self::prev_page_faults`] so the
+    /// the current per-PID values into [`Self::prev_cumulative`] so the
     /// next tick can compute *its* delta.
     pub fn tick(
         &mut self,
@@ -249,7 +302,7 @@ impl SamplerState {
         let mem = sum_memory(snapshots);
         let cum = cumulative_totals(&self.per_pid);
 
-        let (major_delta, minor_delta) = self.compute_and_advance_page_fault_deltas(snapshots);
+        let deltas = self.compute_and_advance_per_tick_deltas(snapshots);
 
         Some(TickRecord {
             elapsed: elapsed_seconds,
@@ -261,51 +314,77 @@ impl SamplerState {
             io_out: cum.io_out.map(bytes_to_mib),
             cpu_time: cum.cpu_time,
             n_procs: snapshots.len(),
-            major_page_faults: major_delta,
-            minor_page_faults: minor_delta,
+            major_page_faults: deltas.major_page_faults,
+            minor_page_faults: deltas.minor_page_faults,
+            voluntary_ctx_switches: deltas.voluntary_ctx_switches,
+            involuntary_ctx_switches: deltas.involuntary_ctx_switches,
         })
     }
 
-    /// For each PID in `snapshots`, return the delta from the previous-tick
-    /// page-fault count (zero if never seen). Sum the deltas across PIDs and
-    /// update [`Self::prev_page_faults`] for the next call.
+    /// For each PID in `snapshots`, compute the delta from the previous-tick
+    /// cumulative counters (zero if never seen) for every per-tick metric,
+    /// summed across PIDs. Advance [`Self::prev_cumulative`] to the current
+    /// values so the next call computes its own correct delta.
     ///
-    /// `Option::None` is returned for major or minor when no process exposed
-    /// that counter this tick — same convention as the I/O fields, so the
-    /// trace TSV renders `-` rather than `0` and consumers can tell "not
-    /// observed" from "observed as zero."
-    fn compute_and_advance_page_fault_deltas(
+    /// Each metric returns `None` when no process exposed it this tick —
+    /// same convention as the I/O fields, so the trace TSV renders `-`
+    /// rather than `0` and consumers can tell "not observed" from "observed
+    /// as zero." `saturating_sub` guards against PID reuse (a recycled PID
+    /// starting at zero must not produce a phantom huge delta).
+    fn compute_and_advance_per_tick_deltas(
         &mut self,
         snapshots: &[ProcessSnapshot],
-    ) -> (Option<u64>, Option<u64>) {
-        let mut major_delta: u64 = 0;
-        let mut minor_delta: u64 = 0;
-        let mut any_major = false;
-        let mut any_minor = false;
+    ) -> PerTickDeltas {
+        let mut major_pf: u64 = 0;
+        let mut minor_pf: u64 = 0;
+        let mut vol_cs: u64 = 0;
+        let mut invol_cs: u64 = 0;
+        let mut any_major_pf = false;
+        let mut any_minor_pf = false;
+        let mut any_vol_cs = false;
+        let mut any_invol_cs = false;
         for snap in snapshots {
-            let prev = self.prev_page_faults.get(&snap.pid).copied().unwrap_or((0, 0));
+            let prev = self.prev_cumulative.get(&snap.pid).copied().unwrap_or_default();
             if let Some(current) = snap.major_page_faults {
-                major_delta = major_delta.saturating_add(current.saturating_sub(prev.0));
-                any_major = true;
+                major_pf = major_pf.saturating_add(current.saturating_sub(prev.major_page_faults));
+                any_major_pf = true;
             }
             if let Some(current) = snap.minor_page_faults {
-                minor_delta = minor_delta.saturating_add(current.saturating_sub(prev.1));
-                any_minor = true;
+                minor_pf = minor_pf.saturating_add(current.saturating_sub(prev.minor_page_faults));
+                any_minor_pf = true;
             }
-            // Advance prev to the current values (treat unobserved as 0 to
-            // avoid a phantom positive delta on next observation).
-            self.prev_page_faults.insert(
+            if let Some(current) = snap.voluntary_ctx_switches {
+                vol_cs = vol_cs.saturating_add(current.saturating_sub(prev.voluntary_ctx_switches));
+                any_vol_cs = true;
+            }
+            if let Some(current) = snap.involuntary_ctx_switches {
+                invol_cs =
+                    invol_cs.saturating_add(current.saturating_sub(prev.involuntary_ctx_switches));
+                any_invol_cs = true;
+            }
+            // Advance prev. Unobserved → preserve prior value (so a metric
+            // that drops out for one tick doesn't fabricate a delta when it
+            // returns); newly observed → use current.
+            self.prev_cumulative.insert(
                 snap.pid,
-                (
-                    snap.major_page_faults.unwrap_or(prev.0),
-                    snap.minor_page_faults.unwrap_or(prev.1),
-                ),
+                PrevCumulative {
+                    major_page_faults: snap.major_page_faults.unwrap_or(prev.major_page_faults),
+                    minor_page_faults: snap.minor_page_faults.unwrap_or(prev.minor_page_faults),
+                    voluntary_ctx_switches: snap
+                        .voluntary_ctx_switches
+                        .unwrap_or(prev.voluntary_ctx_switches),
+                    involuntary_ctx_switches: snap
+                        .involuntary_ctx_switches
+                        .unwrap_or(prev.involuntary_ctx_switches),
+                },
             );
         }
-        (
-            if any_major { Some(major_delta) } else { None },
-            if any_minor { Some(minor_delta) } else { None },
-        )
+        PerTickDeltas {
+            major_page_faults: if any_major_pf { Some(major_pf) } else { None },
+            minor_page_faults: if any_minor_pf { Some(minor_pf) } else { None },
+            voluntary_ctx_switches: if any_vol_cs { Some(vol_cs) } else { None },
+            involuntary_ctx_switches: if any_invol_cs { Some(invol_cs) } else { None },
+        }
     }
 
     /// Materialize the running aggregate into a [`BenchmarkRecord`] given the
@@ -337,6 +416,8 @@ impl SamplerState {
             cpu_time: cum.cpu_time,
             major_page_faults: cum.major_page_faults,
             minor_page_faults: cum.minor_page_faults,
+            voluntary_ctx_switches: cum.voluntary_ctx_switches,
+            involuntary_ctx_switches: cum.involuntary_ctx_switches,
             data_collected: true,
         }
     }
@@ -689,10 +770,10 @@ mod tests {
         assert_eq!(lines[0], TRACE_TSV_HEADER, "first line should be the trace header");
         assert!(lines.len() >= 3, "expected header + multiple data rows, got: {text:?}");
         let mut last_elapsed = -1.0_f64;
+        let expected_cols = TRACE_TSV_HEADER.split('\t').count();
         for row in &lines[1..] {
             let cols: Vec<&str> = row.split('\t').collect();
-            // 9 original trace columns + 2 page-fault delta columns.
-            assert_eq!(cols.len(), 11, "row has wrong column count: {row:?}");
+            assert_eq!(cols.len(), expected_cols, "row has wrong column count: {row:?}");
             let elapsed: f64 = cols[0].parse().expect("elapsed parses");
             assert!(elapsed >= last_elapsed, "elapsed should be monotonic: {row:?}");
             last_elapsed = elapsed;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -48,16 +48,19 @@ fn tsv_output_for_short_lived_command_has_correct_shape() {
     let text = std::fs::read_to_string(&out).expect("read tsv");
     let lines: Vec<&str> = text.lines().collect();
     assert_eq!(lines.len(), 2, "expected header + 1 data row, got: {text:?}");
-    // Default mode (no --snakemake): full schema, 10 Snakemake columns +
-    // 2 tricord-appended columns (page faults).
-    assert_eq!(
-        lines[0],
-        "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\tio_in\tio_out\tmean_load\tcpu_time\t\
-         major_page_faults\tminor_page_faults",
-    );
-
+    // Default mode (no --snakemake): full schema, 10 Snakemake columns
+    // followed by every tricord-added column (page faults, ctx switches, …).
+    // The expected column count is derived from the header so future
+    // metric PRs only need to update the expected header string, not also
+    // the column count.
+    let expected_cols = lines[0].split('\t').count();
     let cols: Vec<&str> = lines[1].split('\t').collect();
-    assert_eq!(cols.len(), 12);
+    assert_eq!(cols.len(), expected_cols);
+    assert!(lines[0].starts_with(
+        "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\tio_in\tio_out\tmean_load\tcpu_time",
+    ));
+    assert!(lines[0].contains("\tmajor_page_faults\tminor_page_faults"));
+    assert!(lines[0].contains("\tvoluntary_ctx_switches\tinvoluntary_ctx_switches"));
     let wall: f64 = cols[0].parse().expect("wall time parses");
     assert!(wall >= 0.5, "wall time {wall} should be at least 0.5s");
     assert!(wall < 5.0, "wall time {wall} should be under 5s");
@@ -109,8 +112,9 @@ fn instant_exit_yields_na_row() {
     let cols: Vec<&str> = row.split('\t').collect();
     // Either we caught a sample (numbers) or we didn't (NA placeholders);
     // both are valid for an essentially-instant child. Just verify the row
-    // is well-formed against the full-mode schema (12 columns).
-    assert_eq!(cols.len(), 12);
+    // is well-formed and matches the header's column count.
+    let header_cols = text.lines().next().expect("header").split('\t').count();
+    assert_eq!(cols.len(), header_cols);
     let wall: f64 = cols[0].parse().expect("wall time parses");
     assert!(wall >= 0.0);
 }
@@ -134,7 +138,8 @@ fn trace_flag_writes_per_tick_tsv() {
     assert_eq!(
         lines[0],
         "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\t\
-         major_page_faults\tminor_page_faults",
+         major_page_faults\tminor_page_faults\t\
+         voluntary_ctx_switches\tinvoluntary_ctx_switches",
         "unexpected trace header",
     );
     assert!(
@@ -143,11 +148,11 @@ fn trace_flag_writes_per_tick_tsv() {
         lines.len()
     );
 
+    let expected_cols = lines[0].split('\t').count();
     let mut last_elapsed = -1.0_f64;
     for row in &lines[1..] {
         let cols: Vec<&str> = row.split('\t').collect();
-        // 9 original trace columns + 2 page-fault delta columns.
-        assert_eq!(cols.len(), 11, "row has wrong column count: {row:?}");
+        assert_eq!(cols.len(), expected_cols, "row has wrong column count: {row:?}");
         let elapsed: f64 = cols[0].parse().expect("elapsed parses");
         assert!(elapsed >= last_elapsed, "elapsed should be monotonic");
         last_elapsed = elapsed;
@@ -168,11 +173,18 @@ fn export_markdown_writes_table_alongside_tsv() {
     let agg = std::fs::read_to_string(&out).expect("aggregate tsv");
     assert_eq!(agg.lines().count(), 2, "aggregate should still be header + 1 row");
 
-    // Markdown table in full mode: header + alignment + one data row per
-    // column in TSV_HEADER_FULL (currently 12 = 10 Snakemake + 2 page faults).
+    // Markdown table in full mode: header + alignment + one row per column
+    // in TSV_HEADER_FULL. Derive the expected line count from the TSV so
+    // metric PRs only need to update one source of truth.
     let md_text = std::fs::read_to_string(&md).expect("markdown file");
+    let agg_text = std::fs::read_to_string(&out).expect("aggregate tsv");
+    let expected_metric_rows = agg_text.lines().next().expect("agg header").split('\t').count();
     let lines: Vec<&str> = md_text.lines().collect();
-    assert_eq!(lines.len(), 14, "expected header + alignment + 12 metric rows: {md_text:?}");
+    assert_eq!(
+        lines.len(),
+        2 + expected_metric_rows,
+        "expected header + alignment + {expected_metric_rows} metric rows: {md_text:?}",
+    );
     assert!(lines[0].starts_with("| metric"), "unexpected header: {}", lines[0]);
     assert!(lines[1].starts_with("|:") && lines[1].ends_with(":|"), "alignment row: {}", lines[1]);
     assert!(lines.iter().any(|l| l.contains("| s ")), "no `s` row: {md_text:?}");
@@ -329,12 +341,16 @@ fn page_faults_appear_in_aggregate_tsv() {
     let text = std::fs::read_to_string(&out).expect("aggregate tsv");
     let header = text.lines().next().expect("header");
     assert!(header.contains("\tmajor_page_faults\tminor_page_faults"), "header: {header}");
+    let header_cols: Vec<&str> = header.split('\t').collect();
     let cols: Vec<&str> = text.lines().nth(1).expect("data row").split('\t').collect();
-    assert_eq!(cols.len(), 12, "expected 10 base columns + 2 page-fault columns: {cols:?}");
+    assert_eq!(cols.len(), header_cols.len(), "row col count mismatches header: {cols:?}");
 
-    // major_page_faults is column index 10; minor is 11.
-    let major = cols[10];
-    let minor = cols[11];
+    // Look up by name so column-order changes don't silently mis-target.
+    let pos = |name: &str| {
+        header_cols.iter().position(|c| *c == name).unwrap_or_else(|| panic!("col {name}"))
+    };
+    let major = cols[pos("major_page_faults")];
+    let minor = cols[pos("minor_page_faults")];
     // major may legitimately be "0" on a warm-cache run; minor on Linux must
     // be > 0 after touching 30 MiB across 4 KiB pages. macOS exposes only
     // major via rusage, so minor is "-" on macOS.
@@ -442,6 +458,65 @@ fn snakemake_strict_mode_does_not_affect_trace_columns() {
     );
 }
 
+/// Voluntary + involuntary context-switch columns are appended in full mode.
+/// On Linux both come from `/proc/<pid>/status`; on macOS the kernel does
+/// not expose them via `proc_pid_rusage`, so both columns render as `-`.
+#[test]
+fn context_switches_appear_in_aggregate_tsv() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    // Several short sleeps generate many voluntary context switches on Linux
+    // (each sleep yields the CPU). The wall time is long enough to guarantee
+    // a tick fires.
+    let result =
+        run_bench(&out, "tsv", &[], &["sh", "-c", "for i in 1 2 3 4 5 6 7 8; do sleep 0.05; done"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let text = std::fs::read_to_string(&out).expect("aggregate tsv");
+    let header = text.lines().next().expect("header");
+    assert!(
+        header.contains("\tvoluntary_ctx_switches\tinvoluntary_ctx_switches"),
+        "header missing ctx-switch cols: {header}",
+    );
+    let header_cols: Vec<&str> = header.split('\t').collect();
+    let cols: Vec<&str> = text.lines().nth(1).expect("data row").split('\t').collect();
+    assert_eq!(cols.len(), header_cols.len(), "row col count mismatches header: {cols:?}");
+
+    // Look up by name so column-order changes don't silently mis-target.
+    let pos = |name: &str| {
+        header_cols.iter().position(|c| *c == name).unwrap_or_else(|| panic!("col {name}"))
+    };
+    let voluntary = cols[pos("voluntary_ctx_switches")];
+    let involuntary = cols[pos("involuntary_ctx_switches")];
+
+    #[cfg(target_os = "linux")]
+    {
+        let v: u64 = voluntary.parse().unwrap_or_else(|_| panic!("vol parses: {voluntary}"));
+        assert!(v > 0, "linux voluntary_ctx_switches {v} should be > 0 after 8 sleeps");
+        let _ = involuntary.parse::<u64>().expect("involuntary parses on linux");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        assert_eq!(voluntary, "-", "macos voluntary_ctx_switches should be `-`");
+        assert_eq!(involuntary, "-", "macos involuntary_ctx_switches should be `-`");
+    }
+}
+
+#[test]
+fn snakemake_strict_mode_strips_ctx_switch_columns() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let result = run_bench(&out, "tsv", &["--snakemake"], &["sh", "-c", "sleep 0.4"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let text = std::fs::read_to_string(&out).unwrap();
+    let header = text.lines().next().unwrap();
+    assert!(!header.contains("voluntary_ctx_switches"), "strict header: {header}");
+    assert!(!header.contains("involuntary_ctx_switches"));
+    let cols: Vec<&str> = text.lines().nth(1).unwrap().split('\t').collect();
+    assert_eq!(cols.len(), 10, "strict mode row must still be 10 cols: {cols:?}");
+}
+
 fn python3_available() -> bool {
     Command::new("python3").arg("--version").output().is_ok_and(|o| o.status.success())
 }
@@ -502,8 +577,10 @@ while time.monotonic() < end:
     let lines: Vec<&str> = text.lines().collect();
     assert_eq!(lines.len(), 2, "expected header + 1 data row, got: {text:?}");
     let cols: Vec<&str> = lines[1].split('\t').collect();
-    // Default (full) mode: 10 Snakemake columns + 2 page-fault columns.
-    assert_eq!(cols.len(), 12);
+    // Default (full) mode: 10 Snakemake columns + every tricord-added
+    // column. Header drives the expected count so future metric PRs need
+    // not edit this assertion.
+    assert_eq!(cols.len(), lines[0].split('\t').count());
 
     let wall: f64 = cols[0].parse().expect("wall");
     let max_rss: f64 = cols[2].parse().expect("max_rss");


### PR DESCRIPTION
Second metric off tracking issue #11. Stacks on #14 (\`nh/page-faults\`) → which stacks on #13 (\`nh/export-markdown\`). Merge the lower PRs first; this one rebases onto main cleanly once the chain lands.

## Summary

- Adds **voluntary + involuntary context-switch tracking** to the aggregate \`BenchmarkRecord\` and the per-tick \`TickRecord\`. Aggregate is per-PID running max summed across the tree (mirrors page faults / CPU / I/O); trace is per-tick delta.
- Linux populates both columns from \`/proc/<pid>/status\` (\`voluntary_ctxt_switches\` and \`nonvoluntary_ctxt_switches\`). macOS leaves both as \`None\` — \`proc_pid_rusage\` does not split context switches and \`proc_taskinfo.pti_csw\` is the *total*, so populating either side with it would be misleading.
- Refactors the previous tick-delta helper into a generalized \`PerTickDeltas\` computer + \`PrevCumulative\` per-PID snapshot. Every new per-tick metric now just needs to extend the \`PrevCumulative\` struct and the delta computation, not duplicate the loop.

## Test infrastructure cleanup (bonus)

Tightens integration-test column-count assertions to derive from the header at runtime instead of hard-coding \`12\` (PR 1) / \`14\` (PR 2) / etc. Subsequent metric PRs (#16, #17, #18) won't need to touch these magic numbers anymore.

## Platform coverage

| Metric | Linux | macOS |
|---|---|---|
| \`voluntary_ctx_switches\` | \`/proc/<pid>/status\` (\`voluntary_ctxt_switches\`) | not exposed by \`proc_pid_rusage\` — column is \`-\` |
| \`involuntary_ctx_switches\` | \`/proc/<pid>/status\` (\`nonvoluntary_ctxt_switches\`) | not exposed — column is \`-\` |

## Test plan

- [x] \`cargo ci-fmt\` clean
- [x] \`cargo ci-lint\` clean
- [x] \`cargo ci-test\` — 81 tests pass (was 79; +2 integration tests for ctx-switch columns and strict-mode strip)
- [x] \`cargo test --doc\` — doctest unchanged but still compiles
- [x] Manual: \`target/debug/tricorder --out /tmp/t.tsv -- sh -c 'for i in 1..8; do sleep 0.05; done'\` shows \`voluntary_ctx_switches > 0\` on Linux, both \`-\` on macOS

## Field names

Linux calls them "voluntary_ctxt_switches" / "nonvoluntary_ctxt_switches"; BSD \`rusage\` calls them "nvcsw" / "nivcsw" with the standard English "involuntary". I went with **\`voluntary_ctx_switches\` / \`involuntary_ctx_switches\`** — "involuntary" matches BSD and is more accessible than "nonvoluntary", and "ctx" is a less cryptic abbreviation than "ctxt".

Closes the context-switches checkbox on #11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voluntary and involuntary context-switch metrics to output. These are captured on Linux and rendered as `-` on macOS where distinction is unavailable.
  * Context-switch data appears in aggregate and per-tick TSV output, plus full-mode JSON and markdown exports.
  * Strict Snakemake mode continues to omit tricord-added metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/tricord/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->