### PR TITLE
feat: track peak thread count and peak process count

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Snakemake schema; the prefix's column order and value formatting are
 identical in both modes.
 
 ```text
-s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches
-12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60	42	1234	80	7
+s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches	peak_n_threads	peak_n_procs
+12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60	42	1234	80	7	13	4
 ```
 
 | Column | Units | Meaning |
@@ -126,6 +126,8 @@ s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_pa
 | `minor_page_faults` | integer | Total minor page faults across the tree. `tricord`-added; omitted under `--snakemake`. Always `-` on macOS — see [Platform notes](#platform-notes). |
 | `voluntary_ctx_switches` | integer | Total voluntary context switches across the tree (processes yielding the CPU on their own — typically waiting on I/O or a sleep). `tricord`-added; omitted under `--snakemake`. Always `-` on macOS. |
 | `involuntary_ctx_switches` | integer | Total involuntary context switches across the tree (processes preempted by the scheduler). `tricord`-added; omitted under `--snakemake`. Always `-` on macOS. |
+| `peak_n_threads` | integer | Peak instantaneous thread count across the tree — max over sampling ticks of the summed per-process thread counts. `tricord`-added; omitted under `--snakemake`. |
+| `peak_n_procs` | integer | Peak instantaneous live-process count across the tree — max over sampling ticks of how many processes were observed. Catches "I asked for 16 workers but the tool spawned 200." `tricord`-added; omitted under `--snakemake`. |
 
 Missing values render as `-`; if the run was too short for any sample to
 succeed, every resource column is `NA`.
@@ -137,10 +139,10 @@ per sampling tick — useful for "did it spike or stay flat?" plots and for
 post-mortem on OOM kills. The aggregate `--out` file is unaffected.
 
 ```text
-s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches
-0.5012	102.30	2048.00	95.20	96.00	1.25	0.50	0.75	3	0	850	12	1
-1.0027	120.45	2048.00	112.10	113.00	2.50	1.00	1.55	3	2	1200	28	3
-1.5042	101.50	2048.00	95.20	96.00	2.50	1.00	2.40	2	0	340	15	0
+s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches	n_threads
+0.5012	102.30	2048.00	95.20	96.00	1.25	0.50	0.75	3	0	850	12	1	5
+1.0027	120.45	2048.00	112.10	113.00	2.50	1.00	1.55	3	2	1200	28	3	7
+1.5042	101.50	2048.00	95.20	96.00	2.50	1.00	2.40	2	0	340	15	0	4
 ```
 
 | Column | Units | Meaning |
@@ -152,6 +154,7 @@ s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs	major_page_faults	minor_page_fau
 | `n_procs` | integer | Number of live processes in this tick |
 | `major_page_faults`, `minor_page_faults` | integer | Page faults that occurred *during this tick* (per-tick delta, summed across observed PIDs). Minor is always `-` on macOS. |
 | `voluntary_ctx_switches`, `involuntary_ctx_switches` | integer | Context switches that occurred *during this tick* (per-tick delta, summed across observed PIDs). Both are always `-` on macOS. |
+| `n_threads` | integer | Live thread count across the tree at this tick (sum across PIDs). Instantaneous, not cumulative. |
 
 Memory columns are instantaneous, so they can go up *or down* between rows;
 I/O, CPU, and the page-fault deltas describe activity within the tick — they
@@ -163,7 +166,7 @@ The trace is `tricord`-native and is **not** affected by `--snakemake`.
 Default (full) mode includes `tricord`-added fields:
 
 ```json
-{"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"major_page_faults":42,"minor_page_faults":1234,"voluntary_ctx_switches":80,"involuntary_ctx_switches":7,"data_collected":true}
+{"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"major_page_faults":42,"minor_page_faults":1234,"voluntary_ctx_switches":80,"involuntary_ctx_switches":7,"peak_n_threads":13,"peak_n_procs":4,"data_collected":true}
 ```
 
 Under `--snakemake` the `tricord`-added keys are *absent* from the object
@@ -220,6 +223,7 @@ macOS implementation uses [`libproc`]'s `proc_pidinfo` and `proc_pid_rusage`
 | `major_page_faults` | `/proc/<pid>/stat` (majflt) | `proc_pid_rusage::ri_pageins` |
 | `minor_page_faults` | `/proc/<pid>/stat` (minflt) | not exposed — column is `-` |
 | `voluntary_ctx_switches`, `involuntary_ctx_switches` | `/proc/<pid>/status` (`voluntary_ctxt_switches`, `nonvoluntary_ctxt_switches`) | not split by `proc_pid_rusage` — both columns are `-` |
+| `peak_n_threads`, `n_threads` | `/proc/<pid>/status` (`threads`) | `proc_taskinfo::pti_threadnum` |
 
 ### macOS PSS approximation
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -121,6 +121,8 @@ mod tests {
             minor_page_faults: Some(120),
             voluntary_ctx_switches: Some(40),
             involuntary_ctx_switches: Some(5),
+            peak_n_threads: Some(6),
+            peak_n_procs: 2,
             data_collected: true,
         }
     }
@@ -132,11 +134,13 @@ mod tests {
         let text = std::str::from_utf8(&buf).unwrap();
         let lines: Vec<&str> = text.lines().collect();
         assert_eq!(lines.len(), 2);
-        assert!(lines[0].ends_with("\tinvoluntary_ctx_switches"));
         assert!(lines[0].contains("\tmajor_page_faults\tminor_page_faults\t"));
+        assert!(lines[0].contains("\tvoluntary_ctx_switches\tinvoluntary_ctx_switches\t"));
+        assert!(lines[0].contains("\tpeak_n_threads\tpeak_n_procs"));
         assert!(lines[1].starts_with("0.5000\t"));
-        // Sample record: major=3, minor=120, voluntary=40, involuntary=5.
-        assert!(lines[1].ends_with("\t3\t120\t40\t5"), "data row: {}", lines[1]);
+        // sample_record(): major=3 minor=120 voluntary=40 involuntary=5
+        //                  peak_n_threads=6 peak_n_procs=2
+        assert!(lines[1].ends_with("\t3\t120\t40\t5\t6\t2"), "data row: {}", lines[1]);
         assert!(text.ends_with('\n'));
     }
 

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -91,6 +91,10 @@ fn sample_process(pid: i32, ticks_per_second: f64) -> Option<ProcessSnapshot> {
     let voluntary_ctx_switches = status.voluntary_ctxt_switches;
     let involuntary_ctx_switches = status.nonvoluntary_ctxt_switches;
 
+    // `/proc/<pid>/status` exposes the live thread count under `Threads:`,
+    // surfaced as `status.threads` by procfs (`u64`).
+    let thread_count = Some(status.threads);
+
     Some(ProcessSnapshot {
         pid,
         rss_bytes,
@@ -104,6 +108,7 @@ fn sample_process(pid: i32, ticks_per_second: f64) -> Option<ProcessSnapshot> {
         minor_page_faults,
         voluntary_ctx_switches,
         involuntary_ctx_switches,
+        thread_count,
     })
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -119,6 +119,9 @@ fn sample_process(pid: i32) -> Option<ProcessSnapshot> {
     let vms_bytes = task.pti_virtual_size;
     let cpu_time_seconds =
         mach_time_to_seconds(task.pti_total_user) + mach_time_to_seconds(task.pti_total_system);
+    // `pti_threadnum` is the live thread count for the task; signed in the
+    // libproc bindings but never negative in practice.
+    let thread_count = u64::try_from(task.pti_threadnum).ok();
 
     let rusage_result: Result<RUsageInfoV4, _> = pidrusage(pid);
     let (uss_bytes, pss_bytes, io_read_bytes, io_write_bytes, major_page_faults) =
@@ -162,6 +165,7 @@ fn sample_process(pid: i32) -> Option<ProcessSnapshot> {
         // granular source we can populate them then.
         voluntary_ctx_switches: None,
         involuntary_ctx_switches: None,
+        thread_count,
     })
 }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -19,7 +19,8 @@ pub const TSV_HEADER: &str =
 pub const TSV_HEADER_FULL: &str = "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\t\
                                    io_in\tio_out\tmean_load\tcpu_time\t\
                                    major_page_faults\tminor_page_faults\t\
-                                   voluntary_ctx_switches\tinvoluntary_ctx_switches";
+                                   voluntary_ctx_switches\tinvoluntary_ctx_switches\t\
+                                   peak_n_threads\tpeak_n_procs";
 
 /// Return the appropriate aggregate header for the requested schema mode.
 #[must_use]
@@ -35,7 +36,8 @@ pub fn tsv_header(mode: SchemaMode) -> &'static str {
 /// [`SchemaMode`] — it always includes every column.
 pub const TRACE_TSV_HEADER: &str = "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\t\
                                     major_page_faults\tminor_page_faults\t\
-                                    voluntary_ctx_switches\tinvoluntary_ctx_switches";
+                                    voluntary_ctx_switches\tinvoluntary_ctx_switches\t\
+                                    n_threads";
 
 /// Aggregate-output schema selector.
 ///
@@ -103,6 +105,10 @@ pub struct TickRecord {
     /// `None` if no process exposed counters this tick — always `None` on
     /// macOS.
     pub involuntary_ctx_switches: Option<u64>,
+    /// Threads currently live across the tree (sum across PIDs in this
+    /// tick). `None` if no process exposed a thread count this tick;
+    /// generally populated on both Linux and macOS.
+    pub n_threads: Option<u64>,
 }
 
 impl TickRecord {
@@ -123,6 +129,7 @@ impl TickRecord {
             self.minor_page_faults,
             self.voluntary_ctx_switches,
             self.involuntary_ctx_switches,
+            self.n_threads,
         ] {
             out.push('\t');
             out.push_str(&format_optional_u64(value));
@@ -176,6 +183,15 @@ pub struct BenchmarkRecord {
     /// Total involuntary context switches observed across the process tree
     /// (summed per-PID maximum). `None` on macOS.
     pub involuntary_ctx_switches: Option<u64>,
+    /// Peak instantaneous thread count across the tree — the max over ticks
+    /// of the summed per-PID thread counts. `None` if no process ever
+    /// exposed a thread count.
+    pub peak_n_threads: Option<u64>,
+    /// Peak instantaneous live-process count across the tree — the max over
+    /// ticks of `snapshots.len()`. Always known when `data_collected` is
+    /// true; renders as `NA` otherwise (matching the existing scalar
+    /// fields like `cpu_time`).
+    pub peak_n_procs: u64,
     /// Whether at least one sample successfully read OS resource counters.
     ///
     /// When `false` the TSV row is rendered with `NA` placeholders for every
@@ -198,8 +214,8 @@ impl BenchmarkRecord {
         write!(out, "{:.4}\t{}", self.running_time, format_hms(self.running_time)).unwrap();
 
         let extra_cols = match mode {
-            // page faults (2) + ctx switches (2)
-            SchemaMode::Full => 4,
+            // page faults (2) + ctx switches (2) + peak n_threads + n_procs
+            SchemaMode::Full => 6,
             SchemaMode::SnakemakeStrict => 0,
         };
 
@@ -223,10 +239,14 @@ impl BenchmarkRecord {
                 self.minor_page_faults,
                 self.voluntary_ctx_switches,
                 self.involuntary_ctx_switches,
+                self.peak_n_threads,
             ] {
                 out.push('\t');
                 out.push_str(&format_optional_u64(value));
             }
+            // peak_n_procs is a plain `u64`, not Option, so render bare —
+            // when `data_collected` is true it's always populated.
+            write!(out, "\t{}", self.peak_n_procs).unwrap();
         }
         out
     }
@@ -318,6 +338,11 @@ impl BenchmarkRecord {
             rows.push(("minor_page_faults", int_cell(self.minor_page_faults)));
             rows.push(("voluntary_ctx_switches", int_cell(self.voluntary_ctx_switches)));
             rows.push(("involuntary_ctx_switches", int_cell(self.involuntary_ctx_switches)));
+            rows.push(("peak_n_threads", int_cell(self.peak_n_threads)));
+            rows.push((
+                "peak_n_procs",
+                if self.data_collected { self.peak_n_procs.to_string() } else { "NA".to_string() },
+            ));
         }
         rows
     }
@@ -434,6 +459,8 @@ mod tests {
             minor_page_faults: Some(1234),
             voluntary_ctx_switches: Some(80),
             involuntary_ctx_switches: Some(7),
+            peak_n_threads: Some(13),
+            peak_n_procs: 4,
             data_collected: true,
         }
     }
@@ -449,17 +476,18 @@ mod tests {
     #[test]
     fn header_full_appends_tricord_columns() {
         assert!(TSV_HEADER_FULL.starts_with(TSV_HEADER));
-        assert!(TSV_HEADER_FULL.ends_with("\tinvoluntary_ctx_switches"));
         // No reordering of the snakemake prefix.
         let strict_cols: Vec<&str> = TSV_HEADER.split('\t').collect();
         let full_cols: Vec<&str> = TSV_HEADER_FULL.split('\t').collect();
         assert_eq!(&full_cols[..strict_cols.len()], &strict_cols[..]);
-        // All four tricord-added columns are present.
+        // Every tricord-added column lives after the snakemake prefix.
         for col in [
             "major_page_faults",
             "minor_page_faults",
             "voluntary_ctx_switches",
             "involuntary_ctx_switches",
+            "peak_n_threads",
+            "peak_n_procs",
         ] {
             assert!(full_cols.contains(&col), "missing {col} in {TSV_HEADER_FULL}");
         }
@@ -520,10 +548,12 @@ mod tests {
 
     #[test]
     fn tsv_row_full_mode_appends_all_tricord_columns() {
+        // full_record(): page faults 42/1234, ctx switches 80/7, peak
+        // threads 13, peak procs 4.
         assert_eq!(
             full_record().to_tsv_row(SchemaMode::Full),
             "12.3456\t0:00:12\t101.50\t2048.00\t95.20\t96.00\t1.25\t0.50\t175.00\t21.60\t\
-             42\t1234\t80\t7",
+             42\t1234\t80\t7\t13\t4",
         );
     }
 
@@ -538,18 +568,18 @@ mod tests {
 
     #[test]
     fn tsv_row_full_mode_renders_missing_tricord_metrics_as_dash() {
+        // Option-typed tricord metrics render as `-` when None; the plain
+        // `peak_n_procs: u64` renders as its bare integer (full_record's 4).
         let record = BenchmarkRecord {
             major_page_faults: None,
             minor_page_faults: None,
             voluntary_ctx_switches: None,
             involuntary_ctx_switches: None,
+            peak_n_threads: None,
             ..full_record()
         };
-        assert!(
-            record.to_tsv_row(SchemaMode::Full).ends_with("\t-\t-\t-\t-"),
-            "row was: {}",
-            record.to_tsv_row(SchemaMode::Full),
-        );
+        let row = record.to_tsv_row(SchemaMode::Full);
+        assert!(row.ends_with("\t-\t-\t-\t-\t-\t4"), "row was: {row}");
     }
 
     #[test]
@@ -601,7 +631,8 @@ mod tests {
             TRACE_TSV_HEADER,
             "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\t\
              major_page_faults\tminor_page_faults\t\
-             voluntary_ctx_switches\tinvoluntary_ctx_switches"
+             voluntary_ctx_switches\tinvoluntary_ctx_switches\t\
+             n_threads"
         );
     }
 
@@ -621,10 +652,11 @@ mod tests {
             minor_page_faults: Some(150),
             voluntary_ctx_switches: Some(11),
             involuntary_ctx_switches: Some(3),
+            n_threads: Some(8),
         };
         assert_eq!(
             tick.to_tsv_row(),
-            "0.5012\t102.30\t2048.00\t95.20\t96.00\t1.25\t0.50\t0.75\t3\t2\t150\t11\t3"
+            "0.5012\t102.30\t2048.00\t95.20\t96.00\t1.25\t0.50\t0.75\t3\t2\t150\t11\t3\t8"
         );
     }
 
@@ -644,15 +676,16 @@ mod tests {
             minor_page_faults: None,
             voluntary_ctx_switches: None,
             involuntary_ctx_switches: None,
+            n_threads: None,
         };
-        assert_eq!(tick.to_tsv_row(), "1.0000\t10.00\t20.00\t-\t-\t-\t-\t0.00\t1\t-\t-\t-\t-");
+        assert_eq!(tick.to_tsv_row(), "1.0000\t10.00\t20.00\t-\t-\t-\t-\t0.00\t1\t-\t-\t-\t-\t-");
     }
 
     #[test]
     fn markdown_full_data_exact_layout() {
-        // Widest label is now "involuntary_ctx_switches" (24 chars), driving
-        // the metric column width. Value widths are still 7 ("12.3456" /
-        // "2048.00" / "0:00:12") — the new int values are shorter.
+        // Widest label is still "involuntary_ctx_switches" (24 chars); the
+        // PR 3 additions ("peak_n_threads", "peak_n_procs") are shorter,
+        // so column widths don't shift. Two new rows at the bottom.
         //
         // When new metrics land (tracking issue #11 on fg-labs/tricord), this
         // golden block needs re-recording — both for the new rows and for any
@@ -674,6 +707,8 @@ mod tests {
 | minor_page_faults        |    1234 |
 | voluntary_ctx_switches   |      80 |
 | involuntary_ctx_switches |       7 |
+| peak_n_threads           |      13 |
+| peak_n_procs             |       4 |
 ";
         assert_eq!(full_record().to_markdown_document(SchemaMode::Full), expected);
     }
@@ -730,6 +765,8 @@ mod tests {
             minor_page_faults: None,
             voluntary_ctx_switches: None,
             involuntary_ctx_switches: None,
+            peak_n_threads: None,
+            peak_n_procs: 1,
             data_collected: true,
         };
         let doc = record.to_markdown_document(SchemaMode::Full);
@@ -741,6 +778,7 @@ mod tests {
             "minor_page_faults",
             "voluntary_ctx_switches",
             "involuntary_ctx_switches",
+            "peak_n_threads",
         ] {
             let row = doc.lines().find(|l| l.contains(metric)).expect("metric row");
             assert!(row.contains(" - "), "expected dash in {metric} row: {row}");

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -65,6 +65,11 @@ pub struct ProcessSnapshot {
     /// Cumulative involuntary context switches for this process. `None` on
     /// macOS.
     pub involuntary_ctx_switches: Option<u64>,
+    /// Number of live threads in this process at sample time. `None` if the
+    /// platform did not expose a thread count this sample. Used to derive
+    /// per-tick `n_threads` (sum across PIDs) and aggregate `peak_n_threads`
+    /// (max of those sums across ticks).
+    pub thread_count: Option<u64>,
 }
 
 /// Per-PID accumulator; used to keep the latest seen value of monotonically-
@@ -99,6 +104,13 @@ pub struct SamplerState {
     /// matching fields on [`ProcessAccum`] (those hold the running maximum
     /// used for aggregate totals; this is a point-in-time snapshot).
     prev_cumulative: HashMap<i32, PrevCumulative>,
+    /// Peak instantaneous live-thread count across the tree (max over ticks
+    /// of summed per-PID `thread_count`). `None` if no process ever exposed
+    /// a thread count.
+    max_n_threads: Option<u64>,
+    /// Peak instantaneous live-process count across the tree (max over
+    /// ticks of `snapshots.len()`).
+    max_n_procs: u64,
     data_collected: bool,
 }
 
@@ -231,6 +243,22 @@ fn bytes_to_mib(bytes: u64) -> f64 {
     (bytes as f64) / (1024.0 * 1024.0)
 }
 
+/// Sum the `thread_count` field across `snapshots`. Returns `None` when no
+/// process in the tick exposed a thread count (older platforms, restricted
+/// access) so the trace column renders `-` rather than `0` and aggregates
+/// stay `None` for the run.
+fn sum_thread_count(snapshots: &[ProcessSnapshot]) -> Option<u64> {
+    let mut total: u64 = 0;
+    let mut any = false;
+    for snap in snapshots {
+        if let Some(t) = snap.thread_count {
+            total = total.saturating_add(t);
+            any = true;
+        }
+    }
+    if any { Some(total) } else { None }
+}
+
 impl SamplerState {
     /// Fold one tick's worth of snapshots into the running aggregate.
     pub fn absorb(&mut self, snapshots: &[ProcessSnapshot]) {
@@ -246,6 +274,13 @@ impl SamplerState {
         if let Some(v) = sums.pss {
             self.max_pss_bytes = Some(self.max_pss_bytes.unwrap_or(0).max(v));
         }
+        // Instantaneous tree-wide thread + process counts at this tick.
+        // Both follow the memory-style "max of per-tick sums" semantics —
+        // they are not cumulative counters with deltas.
+        if let Some(threads) = sum_thread_count(snapshots) {
+            self.max_n_threads = Some(self.max_n_threads.unwrap_or(0).max(threads));
+        }
+        self.max_n_procs = self.max_n_procs.max(snapshots.len() as u64);
         for snap in snapshots {
             let entry = self.per_pid.entry(snap.pid).or_default();
             if let Some(io_in) = snap.io_read_bytes {
@@ -318,6 +353,7 @@ impl SamplerState {
             minor_page_faults: deltas.minor_page_faults,
             voluntary_ctx_switches: deltas.voluntary_ctx_switches,
             involuntary_ctx_switches: deltas.involuntary_ctx_switches,
+            n_threads: sum_thread_count(snapshots),
         })
     }
 
@@ -418,6 +454,8 @@ impl SamplerState {
             minor_page_faults: cum.minor_page_faults,
             voluntary_ctx_switches: cum.voluntary_ctx_switches,
             involuntary_ctx_switches: cum.involuntary_ctx_switches,
+            peak_n_threads: self.max_n_threads,
+            peak_n_procs: self.max_n_procs,
             data_collected: true,
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -135,13 +135,24 @@ fn trace_flag_writes_per_tick_tsv() {
 
     let trace_text = std::fs::read_to_string(&trace).expect("trace tsv");
     let lines: Vec<&str> = trace_text.lines().collect();
-    assert_eq!(
-        lines[0],
-        "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\t\
-         major_page_faults\tminor_page_faults\t\
-         voluntary_ctx_switches\tinvoluntary_ctx_switches",
-        "unexpected trace header",
-    );
+    let trace_header = lines[0];
+    // Spot-check the columns by name rather than locking the exact header
+    // string; future metric PRs append columns without re-recording here.
+    for col in [
+        "s",
+        "rss",
+        "n_procs",
+        "major_page_faults",
+        "minor_page_faults",
+        "voluntary_ctx_switches",
+        "involuntary_ctx_switches",
+        "n_threads",
+    ] {
+        assert!(
+            trace_header.split('\t').any(|c| c == col),
+            "trace header missing {col}: {trace_header}",
+        );
+    }
     assert!(
         lines.len() >= 3,
         "expected header + multiple ticks, got {}: {trace_text:?}",
@@ -515,6 +526,61 @@ fn snakemake_strict_mode_strips_ctx_switch_columns() {
     assert!(!header.contains("involuntary_ctx_switches"));
     let cols: Vec<&str> = text.lines().nth(1).unwrap().split('\t').collect();
     assert_eq!(cols.len(), 10, "strict mode row must still be 10 cols: {cols:?}");
+}
+
+/// Peak thread + process count appear in the full-mode TSV. Both platforms
+/// populate thread counts (procfs and TaskInfo); a workload with multiple
+/// processes drives `peak_n_procs` above 1.
+#[test]
+fn peak_thread_and_proc_counts_appear_in_aggregate_tsv() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    // Two backgrounded sleeps + a foreground sleep ⇒ at least 3 procs in
+    // the tree concurrently for ~0.3s, easily caught by interval=0.1.
+    let result =
+        run_bench(&out, "tsv", &[], &["sh", "-c", "sleep 0.3 & sleep 0.3 & sleep 0.3 ; wait"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let text = std::fs::read_to_string(&out).expect("aggregate tsv");
+    let header = text.lines().next().expect("header");
+    let header_cols: Vec<&str> = header.split('\t').collect();
+    let cols: Vec<&str> = text.lines().nth(1).expect("data row").split('\t').collect();
+    assert_eq!(cols.len(), header_cols.len(), "header/row mismatch");
+
+    let pos = |name: &str| {
+        header_cols.iter().position(|c| *c == name).unwrap_or_else(|| panic!("col {name}"))
+    };
+    let peak_n_procs: u64 = cols[pos("peak_n_procs")].parse().expect("peak_n_procs parses as u64");
+    assert!(peak_n_procs >= 3, "peak_n_procs {peak_n_procs} should reflect 3 concurrent procs");
+    let peak_n_threads: u64 =
+        cols[pos("peak_n_threads")].parse().expect("peak_n_threads parses as u64");
+    assert!(peak_n_threads >= peak_n_procs, "peak_n_threads must be >= peak_n_procs");
+}
+
+#[test]
+fn snakemake_strict_mode_strips_peak_n_columns() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let result = run_bench(&out, "tsv", &["--snakemake"], &["sh", "-c", "sleep 0.3"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let header = std::fs::read_to_string(&out).unwrap().lines().next().unwrap().to_string();
+    assert!(!header.contains("peak_n_threads"), "strict header: {header}");
+    assert!(!header.contains("peak_n_procs"), "strict header: {header}");
+}
+
+#[test]
+fn trace_includes_n_threads_per_tick() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let trace = tmp.path().join("trace.tsv");
+    let trace_str = trace.to_str().expect("utf8");
+    let result = run_bench(&out, "tsv", &["--trace", trace_str], &["sh", "-c", "sleep 0.4"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let trace_text = std::fs::read_to_string(&trace).expect("trace tsv");
+    let header = trace_text.lines().next().expect("trace header");
+    assert!(header.contains("\tn_threads"), "trace header missing n_threads: {header}");
 }
 
 fn python3_available() -> bool {


### PR DESCRIPTION
Third metric off tracking issue #11. Stacks on #15 → #14 → #13. Merge the lower PRs first.

## Summary

- Adds **peak thread count** (`peak_n_threads`) and **peak process count** (`peak_n_procs`) to the aggregate `BenchmarkRecord`; adds **per-tick `n_threads`** to the trace TSV. Per-tick process count is already in the trace as the existing `n_procs` column — no change needed there.
- Linux: `/proc/<pid>/status` `threads` field (via `procfs::Status.threads`). macOS: `proc_taskinfo::pti_threadnum` (signed in libproc bindings, converted via `u64::try_from` for safety). Process count comes from `snapshots.len()` at each tick — works on both platforms with no per-PID query.

## Semantics differ from PRs 1-2

These metrics are **instantaneous**, not cumulative counters with deltas:

- Aggregate: `max` over ticks of summed per-PID thread count (matches `max_rss` semantics, not `io_in` semantics).
- Trace: instantaneous summed thread count per tick. No deltas. The `PerTickDeltas` infrastructure from PR 2 is not used for these columns.

## Type choice

`peak_n_procs` is bare `u64` rather than `Option<u64>` because it's always known when `data_collected` is true (we definitely counted how many snapshots we got). It renders as a bare integer in TSV/JSON and as `NA` in the all-NA short-lived-child placeholder row, matching the scalar-vs-Option pattern of `cpu_time` and `mean_load`.

`peak_n_threads` is `Option<u64>` — both Linux and macOS populate it today, but the `None` fallback exists if a future platform doesn't expose a per-process thread count.

## Test plan

- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [x] `cargo ci-test` — 84 tests pass (was 81; +3 integration tests for peak columns / strict-mode strip / trace `n_threads`)
- [x] `cargo test --doc` clean
- [x] Manual: `target/debug/tricorder --out /tmp/t.tsv -- sh -c 'sleep 0.3 & sleep 0.3 & sleep 0.3 ; wait'` shows `peak_n_procs >= 3`

Closes the thread/process-count checkbox on #11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Now tracks and reports peak thread and process counts in benchmark output
  * Added per-tick thread count tracking to trace output
  * Full-mode output includes new metrics; Snakemake strict mode remains unchanged

* **Documentation**
  * Updated output schema documentation to reflect new thread/process metrics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/tricord/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
