### PR TITLE
feat: track system 1-minute load average at run start and end

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Snakemake schema; the prefix's column order and value formatting are
 identical in both modes.
 
 ```text
-s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches	peak_n_threads	peak_n_procs
-12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60	42	1234	80	7	13	4
+s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches	peak_n_threads	peak_n_procs	loadavg_1m_start	loadavg_1m_end
+12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60	42	1234	80	7	13	4	0.50	2.25
 ```
 
 | Column | Units | Meaning |
@@ -128,6 +128,8 @@ s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_pa
 | `involuntary_ctx_switches` | integer | Total involuntary context switches across the tree (processes preempted by the scheduler). `tricord`-added; omitted under `--snakemake`. Always `-` on macOS. |
 | `peak_n_threads` | integer | Peak instantaneous thread count across the tree — max over sampling ticks of the summed per-process thread counts. `tricord`-added; omitted under `--snakemake`. |
 | `peak_n_procs` | integer | Peak instantaneous live-process count across the tree — max over sampling ticks of how many processes were observed. Catches "I asked for 16 workers but the tool spawned 200." `tricord`-added; omitted under `--snakemake`. |
+| `loadavg_1m_start` | float (`%.2f`) | System 1-minute load average sampled just before the child started. Frames the rest of the numbers — a peak `cpu_time` of 800% on an idle host (loadavg ~1) means something very different from the same peak on a thrashing host. `tricord`-added; omitted under `--snakemake`. |
+| `loadavg_1m_end` | float (`%.2f`) | System 1-minute load average sampled just after the child exited. Paired with `loadavg_1m_start` to show whether the run drove the host load up. `tricord`-added; omitted under `--snakemake`. |
 
 Missing values render as `-`; if the run was too short for any sample to
 succeed, every resource column is `NA`.
@@ -166,7 +168,7 @@ The trace is `tricord`-native and is **not** affected by `--snakemake`.
 Default (full) mode includes `tricord`-added fields:
 
 ```json
-{"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"major_page_faults":42,"minor_page_faults":1234,"voluntary_ctx_switches":80,"involuntary_ctx_switches":7,"peak_n_threads":13,"peak_n_procs":4,"data_collected":true}
+{"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"major_page_faults":42,"minor_page_faults":1234,"voluntary_ctx_switches":80,"involuntary_ctx_switches":7,"peak_n_threads":13,"peak_n_procs":4,"loadavg_1m_start":0.50,"loadavg_1m_end":2.25,"data_collected":true}
 ```
 
 Under `--snakemake` the `tricord`-added keys are *absent* from the object
@@ -224,6 +226,7 @@ macOS implementation uses [`libproc`]'s `proc_pidinfo` and `proc_pid_rusage`
 | `minor_page_faults` | `/proc/<pid>/stat` (minflt) | not exposed — column is `-` |
 | `voluntary_ctx_switches`, `involuntary_ctx_switches` | `/proc/<pid>/status` (`voluntary_ctxt_switches`, `nonvoluntary_ctxt_switches`) | not split by `proc_pid_rusage` — both columns are `-` |
 | `peak_n_threads`, `n_threads` | `/proc/<pid>/status` (`threads`) | `proc_taskinfo::pti_threadnum` |
+| `loadavg_1m_start`, `loadavg_1m_end` | `/proc/loadavg` (first field) | `getloadavg(3)` |
 
 ### macOS PSS approximation
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -123,6 +123,8 @@ mod tests {
             involuntary_ctx_switches: Some(5),
             peak_n_threads: Some(6),
             peak_n_procs: 2,
+            loadavg_1m_start: Some(0.75),
+            loadavg_1m_end: Some(1.10),
             data_collected: true,
         }
     }
@@ -136,11 +138,12 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains("\tmajor_page_faults\tminor_page_faults\t"));
         assert!(lines[0].contains("\tvoluntary_ctx_switches\tinvoluntary_ctx_switches\t"));
-        assert!(lines[0].contains("\tpeak_n_threads\tpeak_n_procs"));
+        assert!(lines[0].contains("\tpeak_n_threads\tpeak_n_procs\t"));
+        assert!(lines[0].contains("\tloadavg_1m_start\tloadavg_1m_end"));
         assert!(lines[1].starts_with("0.5000\t"));
         // sample_record(): major=3 minor=120 voluntary=40 involuntary=5
-        //                  peak_n_threads=6 peak_n_procs=2
-        assert!(lines[1].ends_with("\t3\t120\t40\t5\t6\t2"), "data row: {}", lines[1]);
+        //                  peak_n_threads=6 peak_n_procs=2 loadavg 0.75 → 1.10
+        assert!(lines[1].ends_with("\t3\t120\t40\t5\t6\t2\t0.75\t1.10"), "data row: {}", lines[1]);
         assert!(text.ends_with('\n'));
     }
 

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -112,6 +112,15 @@ fn sample_process(pid: i32, ticks_per_second: f64) -> Option<ProcessSnapshot> {
     })
 }
 
+/// Read the first whitespace-separated field of `/proc/loadavg` — the
+/// kernel's exponentially-weighted 1-minute load average. Returns `None`
+/// if the file is missing or unparseable.
+#[must_use]
+pub fn read_loadavg_1m() -> Option<f64> {
+    let text = std::fs::read_to_string("/proc/loadavg").ok()?;
+    text.split_whitespace().next()?.parse::<f64>().ok()
+}
+
 /// Parse `/proc/<pid>/smaps_rollup` for USS and PSS. Returns `(None, None)` if
 /// the file cannot be read (older kernels, restricted access).
 fn read_smaps_rollup(proc: &Process) -> (Option<u64>, Option<u64>) {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -33,6 +33,21 @@ struct MachTimebaseInfo {
 
 unsafe extern "C" {
     fn mach_timebase_info(info: *mut MachTimebaseInfo) -> i32;
+    /// `getloadavg(double[] loadavg, int nelem)` — fills the first `nelem`
+    /// slots with the 1/5/15-minute kernel load averages, returns the
+    /// number actually written (or -1 on error). Stable BSD API.
+    fn getloadavg(loadavg: *mut f64, nelem: i32) -> i32;
+}
+
+/// Read the system 1-minute load average via `getloadavg(3)`. Returns
+/// `None` on error (which shouldn't happen on any supported macOS).
+#[must_use]
+pub fn read_loadavg_1m() -> Option<f64> {
+    let mut buf = [0.0_f64; 1];
+    // SAFETY: getloadavg writes at most `nelem` doubles to the buffer.
+    // We pass 1 and an exactly-1-element buffer.
+    let written = unsafe { getloadavg(buf.as_mut_ptr(), 1) };
+    if written < 1 { None } else { Some(buf[0]) }
 }
 
 /// `(numer, denom)` from `mach_timebase_info`, cached once per process.

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -37,3 +37,21 @@ pub fn new_sampler() -> Box<dyn ProcessSampler> {
         compile_error!("tricord supports Linux and macOS only");
     }
 }
+
+/// Read the system 1-minute load average, in "tasks ready to run" units.
+///
+/// Returns `None` if the platform read fails. Used by `run_command` to
+/// snapshot system context at run start and end — the value frames the
+/// per-process numbers ("peak CPU 800 % on an idle box vs the same peak
+/// on a thrashing host").
+#[must_use]
+pub fn read_loadavg_1m() -> Option<f64> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::read_loadavg_1m()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos::read_loadavg_1m()
+    }
+}

--- a/src/record.rs
+++ b/src/record.rs
@@ -20,7 +20,8 @@ pub const TSV_HEADER_FULL: &str = "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\
                                    io_in\tio_out\tmean_load\tcpu_time\t\
                                    major_page_faults\tminor_page_faults\t\
                                    voluntary_ctx_switches\tinvoluntary_ctx_switches\t\
-                                   peak_n_threads\tpeak_n_procs";
+                                   peak_n_threads\tpeak_n_procs\t\
+                                   loadavg_1m_start\tloadavg_1m_end";
 
 /// Return the appropriate aggregate header for the requested schema mode.
 #[must_use]
@@ -192,6 +193,15 @@ pub struct BenchmarkRecord {
     /// true; renders as `NA` otherwise (matching the existing scalar
     /// fields like `cpu_time`).
     pub peak_n_procs: u64,
+    /// System 1-minute load average sampled just before `tricord` started
+    /// the child. `None` if the platform read failed.
+    pub loadavg_1m_start: Option<f64>,
+    /// System 1-minute load average sampled just after the child exited.
+    /// `None` if the platform read failed. Pairing start + end frames the
+    /// rest of the numbers: a peak `cpu_time` of 800 % on an idle host
+    /// (loadavg ~1) means something very different from the same peak on
+    /// a thrashing host (loadavg 30).
+    pub loadavg_1m_end: Option<f64>,
     /// Whether at least one sample successfully read OS resource counters.
     ///
     /// When `false` the TSV row is rendered with `NA` placeholders for every
@@ -215,7 +225,8 @@ impl BenchmarkRecord {
 
         let extra_cols = match mode {
             // page faults (2) + ctx switches (2) + peak n_threads + n_procs
-            SchemaMode::Full => 6,
+            // + loadavg start/end (2) = 8
+            SchemaMode::Full => 8,
             SchemaMode::SnakemakeStrict => 0,
         };
 
@@ -247,6 +258,10 @@ impl BenchmarkRecord {
             // peak_n_procs is a plain `u64`, not Option, so render bare —
             // when `data_collected` is true it's always populated.
             write!(out, "\t{}", self.peak_n_procs).unwrap();
+            for value in [self.loadavg_1m_start, self.loadavg_1m_end] {
+                out.push('\t');
+                out.push_str(&format_optional_float(value));
+            }
         }
         out
     }
@@ -343,6 +358,8 @@ impl BenchmarkRecord {
                 "peak_n_procs",
                 if self.data_collected { self.peak_n_procs.to_string() } else { "NA".to_string() },
             ));
+            rows.push(("loadavg_1m_start", cell(self.loadavg_1m_start)));
+            rows.push(("loadavg_1m_end", cell(self.loadavg_1m_end)));
         }
         rows
     }
@@ -461,6 +478,8 @@ mod tests {
             involuntary_ctx_switches: Some(7),
             peak_n_threads: Some(13),
             peak_n_procs: 4,
+            loadavg_1m_start: Some(0.50),
+            loadavg_1m_end: Some(2.25),
             data_collected: true,
         }
     }
@@ -549,11 +568,11 @@ mod tests {
     #[test]
     fn tsv_row_full_mode_appends_all_tricord_columns() {
         // full_record(): page faults 42/1234, ctx switches 80/7, peak
-        // threads 13, peak procs 4.
+        // threads 13, peak procs 4, loadavg 0.50 → 2.25.
         assert_eq!(
             full_record().to_tsv_row(SchemaMode::Full),
             "12.3456\t0:00:12\t101.50\t2048.00\t95.20\t96.00\t1.25\t0.50\t175.00\t21.60\t\
-             42\t1234\t80\t7\t13\t4",
+             42\t1234\t80\t7\t13\t4\t0.50\t2.25",
         );
     }
 
@@ -570,16 +589,19 @@ mod tests {
     fn tsv_row_full_mode_renders_missing_tricord_metrics_as_dash() {
         // Option-typed tricord metrics render as `-` when None; the plain
         // `peak_n_procs: u64` renders as its bare integer (full_record's 4).
+        // Loadavg fields are Option<f64>, also render as `-`.
         let record = BenchmarkRecord {
             major_page_faults: None,
             minor_page_faults: None,
             voluntary_ctx_switches: None,
             involuntary_ctx_switches: None,
             peak_n_threads: None,
+            loadavg_1m_start: None,
+            loadavg_1m_end: None,
             ..full_record()
         };
         let row = record.to_tsv_row(SchemaMode::Full);
-        assert!(row.ends_with("\t-\t-\t-\t-\t-\t4"), "row was: {row}");
+        assert!(row.ends_with("\t-\t-\t-\t-\t-\t4\t-\t-"), "row was: {row}");
     }
 
     #[test]
@@ -683,9 +705,9 @@ mod tests {
 
     #[test]
     fn markdown_full_data_exact_layout() {
-        // Widest label is still "involuntary_ctx_switches" (24 chars); the
-        // PR 3 additions ("peak_n_threads", "peak_n_procs") are shorter,
-        // so column widths don't shift. Two new rows at the bottom.
+        // Widest label is still "involuntary_ctx_switches" (24 chars); PR 4
+        // adds "loadavg_1m_start"/"loadavg_1m_end" (16 chars) — narrower,
+        // so widths don't shift. Two new rows at the bottom.
         //
         // When new metrics land (tracking issue #11 on fg-labs/tricord), this
         // golden block needs re-recording — both for the new rows and for any
@@ -709,6 +731,8 @@ mod tests {
 | involuntary_ctx_switches |       7 |
 | peak_n_threads           |      13 |
 | peak_n_procs             |       4 |
+| loadavg_1m_start         |    0.50 |
+| loadavg_1m_end           |    2.25 |
 ";
         assert_eq!(full_record().to_markdown_document(SchemaMode::Full), expected);
     }
@@ -767,6 +791,8 @@ mod tests {
             involuntary_ctx_switches: None,
             peak_n_threads: None,
             peak_n_procs: 1,
+            loadavg_1m_start: None,
+            loadavg_1m_end: None,
             data_collected: true,
         };
         let doc = record.to_markdown_document(SchemaMode::Full);
@@ -779,6 +805,8 @@ mod tests {
             "voluntary_ctx_switches",
             "involuntary_ctx_switches",
             "peak_n_threads",
+            "loadavg_1m_start",
+            "loadavg_1m_end",
         ] {
             let row = doc.lines().find(|l| l.contains(metric)).expect("metric row");
             assert!(row.contains(" - "), "expected dash in {metric} row: {row}");

--- a/src/run.rs
+++ b/src/run.rs
@@ -10,6 +10,7 @@ use std::{
 
 use crate::{
     format::{self, OutputFormat},
+    platform,
     record::{BenchmarkRecord, SchemaMode},
     sampler::{SamplerHandle, SamplerOptions},
     signals::SignalForwarder,
@@ -88,13 +89,20 @@ pub fn run_command(command: &str, args: &[String], options: &RunOptions) -> io::
     // Install signal forwarding before the sampler so a fast Ctrl-C still
     // reaches the child even if the sampler thread hasn't started yet.
     let signals = SignalForwarder::install(child_pid)?;
+    // Snapshot system loadavg just before the sampler starts so the
+    // "start" value reflects load entering the run (before our child has
+    // had time to contribute meaningfully to the EMA).
+    let loadavg_start = platform::read_loadavg_1m();
     let sampler = SamplerHandle::spawn(
         child_pid,
         SamplerOptions { interval: options.interval, trace_path: options.trace_path.clone() },
     );
 
     let status = child.wait()?;
-    let record = sampler.stop();
+    let mut record = sampler.stop();
+    let loadavg_end = platform::read_loadavg_1m();
+    record.loadavg_1m_start = loadavg_start;
+    record.loadavg_1m_end = loadavg_end;
     drop(signals);
 
     format::write_to_path(&record, &options.output_path, options.format, options.schema_mode)?;

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -456,6 +456,10 @@ impl SamplerState {
             involuntary_ctx_switches: cum.involuntary_ctx_switches,
             peak_n_threads: self.max_n_threads,
             peak_n_procs: self.max_n_procs,
+            // Loadavg start/end are captured by run_command around the
+            // sampler's lifetime, not inside the sampler itself.
+            loadavg_1m_start: None,
+            loadavg_1m_end: None,
             data_collected: true,
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -583,6 +583,62 @@ fn trace_includes_n_threads_per_tick() {
     assert!(header.contains("\tn_threads"), "trace header missing n_threads: {header}");
 }
 
+/// System 1-minute load average is sampled at start and end of the run
+/// and added as two aggregate columns. Trace TSV is intentionally not
+/// touched — loadavg is already a moving average so per-tick samples
+/// would mostly be noise on the same kernel-side smoothing.
+#[test]
+fn loadavg_start_and_end_appear_in_aggregate_tsv() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let result = run_bench(&out, "tsv", &[], &["sh", "-c", "sleep 0.3"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let text = std::fs::read_to_string(&out).expect("aggregate tsv");
+    let header = text.lines().next().expect("header");
+    let header_cols: Vec<&str> = header.split('\t').collect();
+    let cols: Vec<&str> = text.lines().nth(1).expect("data row").split('\t').collect();
+    let pos = |name: &str| {
+        header_cols.iter().position(|c| *c == name).unwrap_or_else(|| panic!("col {name}"))
+    };
+    let start: f64 =
+        cols[pos("loadavg_1m_start")].parse().expect("loadavg_1m_start parses as float");
+    let end: f64 = cols[pos("loadavg_1m_end")].parse().expect("loadavg_1m_end parses as float");
+    // Loadavg is non-negative; on idle laptops it can be near zero, so >= 0 is
+    // the safe lower bound. Upper bound is generous to absorb any contention.
+    assert!(start >= 0.0, "loadavg_1m_start {start} must be >= 0");
+    assert!(end >= 0.0, "loadavg_1m_end {end} must be >= 0");
+    assert!(start < 10_000.0 && end < 10_000.0, "loadavg unexpectedly huge");
+}
+
+#[test]
+fn snakemake_strict_mode_strips_loadavg_columns() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let result = run_bench(&out, "tsv", &["--snakemake"], &["sh", "-c", "sleep 0.3"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let header = std::fs::read_to_string(&out).unwrap().lines().next().unwrap().to_string();
+    assert!(!header.contains("loadavg_1m_start"), "strict header: {header}");
+    assert!(!header.contains("loadavg_1m_end"), "strict header: {header}");
+}
+
+#[test]
+fn loadavg_is_not_added_to_trace_columns() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let trace = tmp.path().join("trace.tsv");
+    let trace_str = trace.to_str().unwrap();
+    let result = run_bench(&out, "tsv", &["--trace", trace_str], &["sh", "-c", "sleep 0.4"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let trace_header = std::fs::read_to_string(&trace).unwrap().lines().next().unwrap().to_string();
+    assert!(
+        !trace_header.contains("loadavg"),
+        "trace TSV must not include loadavg (it's already a smoothed avg): {trace_header}",
+    );
+}
+
 fn python3_available() -> bool {
     Command::new("python3").arg("--version").output().is_ok_and(|o| o.status.success())
 }


### PR DESCRIPTION
Fourth metric off tracking issue #11. Stacks on #16 → #15 → #14 → #13.

## Summary

- Captures the kernel's 1-minute load average once just before the sampler starts and once after the child exits — two new aggregate columns `loadavg_1m_start` and `loadavg_1m_end`. Trace TSV is intentionally **not** touched (loadavg is itself a kernel-side exponentially-weighted moving average; per-tick samples would mostly be re-smoothing the same data, matching the design call from the tracking issue).
- Linux: parses the first field of `/proc/loadavg`. macOS: calls `getloadavg(3)` via FFI (stable BSD API, single C call, minimal documented `unsafe`).

## Why both endpoints

Pairing start and end frames the rest of the numbers: a peak `cpu_time` of 800 % on an idle host (loadavg ~1) means something very different from the same peak on a thrashing host (loadavg 30). A single-value design loses that framing. Spending two columns to gain it is a fair trade.

## Why not in the sampler

`read_loadavg_1m()` is a *system-level* metric, not a per-process one — so it lives alongside the per-process samplers in the platform module but is called by `run_command` rather than threaded through `SamplerState`. The sampler stays process-tree-focused. `run_command` patches the record's two loadavg fields after `sampler.stop()` returns. Minimal coupling, no new sampler state.

## Test plan

- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [x] `cargo ci-test` — 87 tests pass (was 84; +3 integration tests for loadavg cols / strict-mode strip / trace-stays-untouched)
- [x] `cargo test --doc` clean
- [x] Manual: `target/debug/tricorder --out /tmp/t.tsv -- sleep 0.3` shows non-negative floats in both loadavg columns on both Linux and macOS

Closes the loadavg checkbox on #11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two full-mode metrics: loadavg_1m_start and loadavg_1m_end appear in TSV, JSON, and Markdown full outputs (omitted in snakemake-strict mode).

* **Documentation**
  * README updated to document the new fields and platform-specific sourcing for load averages on Linux and macOS.

* **Tests**
  * New end-to-end tests validate loadavg columns, snakemake exclusion, and trace output absence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/tricord/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
