### PR TITLE
feat: track peak swap usage across the process tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Snakemake schema; the prefix's column order and value formatting are
 identical in both modes.
 
 ```text
-s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches	peak_n_threads	peak_n_procs	loadavg_1m_start	loadavg_1m_end
-12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60	42	1234	80	7	13	4	0.50	2.25
+s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches	peak_n_threads	peak_n_procs	loadavg_1m_start	loadavg_1m_end	max_swap
+12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60	42	1234	80	7	13	4	0.50	2.25	64.00
 ```
 
 | Column | Units | Meaning |
@@ -130,6 +130,7 @@ s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_pa
 | `peak_n_procs` | integer | Peak instantaneous live-process count across the tree — max over sampling ticks of how many processes were observed. Catches "I asked for 16 workers but the tool spawned 200." `tricord`-added; omitted under `--snakemake`. |
 | `loadavg_1m_start` | float (`%.2f`) | System 1-minute load average sampled just before the child started. Frames the rest of the numbers — a peak `cpu_time` of 800% on an idle host (loadavg ~1) means something very different from the same peak on a thrashing host. `tricord`-added; omitted under `--snakemake`. |
 | `loadavg_1m_end` | float (`%.2f`) | System 1-minute load average sampled just after the child exited. Paired with `loadavg_1m_start` to show whether the run drove the host load up. `tricord`-added; omitted under `--snakemake`. |
+| `max_swap` | MiB | Peak summed swap usage across the process tree (max over sampling ticks of `VmSwap` summed across PIDs). `tricord`-added; omitted under `--snakemake`. Always `-` on macOS — the kernel has no public per-process swap-usage API. |
 
 Missing values render as `-`; if the run was too short for any sample to
 succeed, every resource column is `NA`.
@@ -141,10 +142,10 @@ per sampling tick — useful for "did it spike or stay flat?" plots and for
 post-mortem on OOM kills. The aggregate `--out` file is unaffected.
 
 ```text
-s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches	n_threads
-0.5012	102.30	2048.00	95.20	96.00	1.25	0.50	0.75	3	0	850	12	1	5
-1.0027	120.45	2048.00	112.10	113.00	2.50	1.00	1.55	3	2	1200	28	3	7
-1.5042	101.50	2048.00	95.20	96.00	2.50	1.00	2.40	2	0	340	15	0	4
+s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches	n_threads	swap
+0.5012	102.30	2048.00	95.20	96.00	1.25	0.50	0.75	3	0	850	12	1	5	0.00
+1.0027	120.45	2048.00	112.10	113.00	2.50	1.00	1.55	3	2	1200	28	3	7	16.50
+1.5042	101.50	2048.00	95.20	96.00	2.50	1.00	2.40	2	0	340	15	0	4	8.25
 ```
 
 | Column | Units | Meaning |
@@ -157,6 +158,7 @@ s	rss	vms	uss	pss	io_in	io_out	cpu_time	n_procs	major_page_faults	minor_page_fau
 | `major_page_faults`, `minor_page_faults` | integer | Page faults that occurred *during this tick* (per-tick delta, summed across observed PIDs). Minor is always `-` on macOS. |
 | `voluntary_ctx_switches`, `involuntary_ctx_switches` | integer | Context switches that occurred *during this tick* (per-tick delta, summed across observed PIDs). Both are always `-` on macOS. |
 | `n_threads` | integer | Live thread count across the tree at this tick (sum across PIDs). Instantaneous, not cumulative. |
+| `swap` | MiB | Summed swap usage across the live tree at this tick. Instantaneous, not cumulative. Always `-` on macOS. |
 
 Memory columns are instantaneous, so they can go up *or down* between rows;
 I/O, CPU, and the page-fault deltas describe activity within the tick — they
@@ -168,7 +170,7 @@ The trace is `tricord`-native and is **not** affected by `--snakemake`.
 Default (full) mode includes `tricord`-added fields:
 
 ```json
-{"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"major_page_faults":42,"minor_page_faults":1234,"voluntary_ctx_switches":80,"involuntary_ctx_switches":7,"peak_n_threads":13,"peak_n_procs":4,"loadavg_1m_start":0.50,"loadavg_1m_end":2.25,"data_collected":true}
+{"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"major_page_faults":42,"minor_page_faults":1234,"voluntary_ctx_switches":80,"involuntary_ctx_switches":7,"peak_n_threads":13,"peak_n_procs":4,"loadavg_1m_start":0.50,"loadavg_1m_end":2.25,"max_swap":64.0,"data_collected":true}
 ```
 
 Under `--snakemake` the `tricord`-added keys are *absent* from the object
@@ -227,6 +229,7 @@ macOS implementation uses [`libproc`]'s `proc_pidinfo` and `proc_pid_rusage`
 | `voluntary_ctx_switches`, `involuntary_ctx_switches` | `/proc/<pid>/status` (`voluntary_ctxt_switches`, `nonvoluntary_ctxt_switches`) | not split by `proc_pid_rusage` — both columns are `-` |
 | `peak_n_threads`, `n_threads` | `/proc/<pid>/status` (`threads`) | `proc_taskinfo::pti_threadnum` |
 | `loadavg_1m_start`, `loadavg_1m_end` | `/proc/loadavg` (first field) | `getloadavg(3)` |
+| `max_swap`, `swap` | `/proc/<pid>/status` (`VmSwap`) | not exposed — both columns are `-` |
 
 ### macOS PSS approximation
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -125,6 +125,7 @@ mod tests {
             peak_n_procs: 2,
             loadavg_1m_start: Some(0.75),
             loadavg_1m_end: Some(1.10),
+            max_swap: Some(0.25),
             data_collected: true,
         }
     }
@@ -139,11 +140,17 @@ mod tests {
         assert!(lines[0].contains("\tmajor_page_faults\tminor_page_faults\t"));
         assert!(lines[0].contains("\tvoluntary_ctx_switches\tinvoluntary_ctx_switches\t"));
         assert!(lines[0].contains("\tpeak_n_threads\tpeak_n_procs\t"));
-        assert!(lines[0].contains("\tloadavg_1m_start\tloadavg_1m_end"));
+        assert!(lines[0].contains("\tloadavg_1m_start\tloadavg_1m_end\t"));
+        assert!(lines[0].ends_with("\tmax_swap"));
         assert!(lines[1].starts_with("0.5000\t"));
         // sample_record(): major=3 minor=120 voluntary=40 involuntary=5
         //                  peak_n_threads=6 peak_n_procs=2 loadavg 0.75 → 1.10
-        assert!(lines[1].ends_with("\t3\t120\t40\t5\t6\t2\t0.75\t1.10"), "data row: {}", lines[1]);
+        //                  max_swap=0.25
+        assert!(
+            lines[1].ends_with("\t3\t120\t40\t5\t6\t2\t0.75\t1.10\t0.25"),
+            "data row: {}",
+            lines[1]
+        );
         assert!(text.ends_with('\n'));
     }
 

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -95,6 +95,12 @@ fn sample_process(pid: i32, ticks_per_second: f64) -> Option<ProcessSnapshot> {
     // surfaced as `status.threads` by procfs (`u64`).
     let thread_count = Some(status.threads);
 
+    // `/proc/<pid>/status` reports `VmSwap:` in kB when the process has
+    // anything swapped out; the field is absent on kernels without swap
+    // accounting per-process, hence `Option`. Multiply to bytes for the
+    // common sampler aggregation path.
+    let swap_bytes = status.vmswap.map(|kb| kb.saturating_mul(1024));
+
     Some(ProcessSnapshot {
         pid,
         rss_bytes,
@@ -109,6 +115,7 @@ fn sample_process(pid: i32, ticks_per_second: f64) -> Option<ProcessSnapshot> {
         voluntary_ctx_switches,
         involuntary_ctx_switches,
         thread_count,
+        swap_bytes,
     })
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -181,6 +181,11 @@ fn sample_process(pid: i32) -> Option<ProcessSnapshot> {
         voluntary_ctx_switches: None,
         involuntary_ctx_switches: None,
         thread_count,
+        // macOS has no public per-process swap-usage API. The Mach VM
+        // statistics aggregate system-wide swap activity but cannot be
+        // attributed per task; leaving as `None` mirrors the existing
+        // pattern for minor_page_faults / ctx switches on macOS.
+        swap_bytes: None,
     })
 }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -21,7 +21,8 @@ pub const TSV_HEADER_FULL: &str = "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\
                                    major_page_faults\tminor_page_faults\t\
                                    voluntary_ctx_switches\tinvoluntary_ctx_switches\t\
                                    peak_n_threads\tpeak_n_procs\t\
-                                   loadavg_1m_start\tloadavg_1m_end";
+                                   loadavg_1m_start\tloadavg_1m_end\t\
+                                   max_swap";
 
 /// Return the appropriate aggregate header for the requested schema mode.
 #[must_use]
@@ -38,7 +39,7 @@ pub fn tsv_header(mode: SchemaMode) -> &'static str {
 pub const TRACE_TSV_HEADER: &str = "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\t\
                                     major_page_faults\tminor_page_faults\t\
                                     voluntary_ctx_switches\tinvoluntary_ctx_switches\t\
-                                    n_threads";
+                                    n_threads\tswap";
 
 /// Aggregate-output schema selector.
 ///
@@ -110,6 +111,10 @@ pub struct TickRecord {
     /// tick). `None` if no process exposed a thread count this tick;
     /// generally populated on both Linux and macOS.
     pub n_threads: Option<u64>,
+    /// Instantaneous summed swap usage across the live tree at this tick,
+    /// in MiB. `None` if no process exposed swap counters this tick —
+    /// always `None` on macOS (no public per-process swap API).
+    pub swap: Option<f64>,
 }
 
 impl TickRecord {
@@ -135,6 +140,8 @@ impl TickRecord {
             out.push('\t');
             out.push_str(&format_optional_u64(value));
         }
+        out.push('\t');
+        out.push_str(&format_optional_float(self.swap));
         out
     }
 }
@@ -202,6 +209,10 @@ pub struct BenchmarkRecord {
     /// (loadavg ~1) means something very different from the same peak on
     /// a thrashing host (loadavg 30).
     pub loadavg_1m_end: Option<f64>,
+    /// Peak summed swap usage across the process tree, in MiB. `None` if
+    /// no process exposed swap counters during the run — always `None` on
+    /// macOS (the kernel has no public per-process swap-usage API).
+    pub max_swap: Option<f64>,
     /// Whether at least one sample successfully read OS resource counters.
     ///
     /// When `false` the TSV row is rendered with `NA` placeholders for every
@@ -225,8 +236,8 @@ impl BenchmarkRecord {
 
         let extra_cols = match mode {
             // page faults (2) + ctx switches (2) + peak n_threads + n_procs
-            // + loadavg start/end (2) = 8
-            SchemaMode::Full => 8,
+            // + loadavg start/end (2) + max_swap = 9
+            SchemaMode::Full => 9,
             SchemaMode::SnakemakeStrict => 0,
         };
 
@@ -258,7 +269,7 @@ impl BenchmarkRecord {
             // peak_n_procs is a plain `u64`, not Option, so render bare —
             // when `data_collected` is true it's always populated.
             write!(out, "\t{}", self.peak_n_procs).unwrap();
-            for value in [self.loadavg_1m_start, self.loadavg_1m_end] {
+            for value in [self.loadavg_1m_start, self.loadavg_1m_end, self.max_swap] {
                 out.push('\t');
                 out.push_str(&format_optional_float(value));
             }
@@ -360,6 +371,7 @@ impl BenchmarkRecord {
             ));
             rows.push(("loadavg_1m_start", cell(self.loadavg_1m_start)));
             rows.push(("loadavg_1m_end", cell(self.loadavg_1m_end)));
+            rows.push(("max_swap", cell(self.max_swap)));
         }
         rows
     }
@@ -480,6 +492,7 @@ mod tests {
             peak_n_procs: 4,
             loadavg_1m_start: Some(0.50),
             loadavg_1m_end: Some(2.25),
+            max_swap: Some(64.00),
             data_collected: true,
         }
     }
@@ -568,11 +581,11 @@ mod tests {
     #[test]
     fn tsv_row_full_mode_appends_all_tricord_columns() {
         // full_record(): page faults 42/1234, ctx switches 80/7, peak
-        // threads 13, peak procs 4, loadavg 0.50 → 2.25.
+        // threads 13, peak procs 4, loadavg 0.50 → 2.25, max_swap 64.00.
         assert_eq!(
             full_record().to_tsv_row(SchemaMode::Full),
             "12.3456\t0:00:12\t101.50\t2048.00\t95.20\t96.00\t1.25\t0.50\t175.00\t21.60\t\
-             42\t1234\t80\t7\t13\t4\t0.50\t2.25",
+             42\t1234\t80\t7\t13\t4\t0.50\t2.25\t64.00",
         );
     }
 
@@ -589,7 +602,7 @@ mod tests {
     fn tsv_row_full_mode_renders_missing_tricord_metrics_as_dash() {
         // Option-typed tricord metrics render as `-` when None; the plain
         // `peak_n_procs: u64` renders as its bare integer (full_record's 4).
-        // Loadavg fields are Option<f64>, also render as `-`.
+        // Loadavg + max_swap fields are Option<f64>, also render as `-`.
         let record = BenchmarkRecord {
             major_page_faults: None,
             minor_page_faults: None,
@@ -598,10 +611,11 @@ mod tests {
             peak_n_threads: None,
             loadavg_1m_start: None,
             loadavg_1m_end: None,
+            max_swap: None,
             ..full_record()
         };
         let row = record.to_tsv_row(SchemaMode::Full);
-        assert!(row.ends_with("\t-\t-\t-\t-\t-\t4\t-\t-"), "row was: {row}");
+        assert!(row.ends_with("\t-\t-\t-\t-\t-\t4\t-\t-\t-"), "row was: {row}");
     }
 
     #[test]
@@ -654,7 +668,7 @@ mod tests {
             "s\trss\tvms\tuss\tpss\tio_in\tio_out\tcpu_time\tn_procs\t\
              major_page_faults\tminor_page_faults\t\
              voluntary_ctx_switches\tinvoluntary_ctx_switches\t\
-             n_threads"
+             n_threads\tswap"
         );
     }
 
@@ -675,10 +689,11 @@ mod tests {
             voluntary_ctx_switches: Some(11),
             involuntary_ctx_switches: Some(3),
             n_threads: Some(8),
+            swap: Some(16.50),
         };
         assert_eq!(
             tick.to_tsv_row(),
-            "0.5012\t102.30\t2048.00\t95.20\t96.00\t1.25\t0.50\t0.75\t3\t2\t150\t11\t3\t8"
+            "0.5012\t102.30\t2048.00\t95.20\t96.00\t1.25\t0.50\t0.75\t3\t2\t150\t11\t3\t8\t16.50"
         );
     }
 
@@ -699,8 +714,12 @@ mod tests {
             voluntary_ctx_switches: None,
             involuntary_ctx_switches: None,
             n_threads: None,
+            swap: None,
         };
-        assert_eq!(tick.to_tsv_row(), "1.0000\t10.00\t20.00\t-\t-\t-\t-\t0.00\t1\t-\t-\t-\t-\t-");
+        assert_eq!(
+            tick.to_tsv_row(),
+            "1.0000\t10.00\t20.00\t-\t-\t-\t-\t0.00\t1\t-\t-\t-\t-\t-\t-"
+        );
     }
 
     #[test]
@@ -733,6 +752,7 @@ mod tests {
 | peak_n_procs             |       4 |
 | loadavg_1m_start         |    0.50 |
 | loadavg_1m_end           |    2.25 |
+| max_swap                 |   64.00 |
 ";
         assert_eq!(full_record().to_markdown_document(SchemaMode::Full), expected);
     }
@@ -793,6 +813,7 @@ mod tests {
             peak_n_procs: 1,
             loadavg_1m_start: None,
             loadavg_1m_end: None,
+            max_swap: None,
             data_collected: true,
         };
         let doc = record.to_markdown_document(SchemaMode::Full);
@@ -807,6 +828,7 @@ mod tests {
             "peak_n_threads",
             "loadavg_1m_start",
             "loadavg_1m_end",
+            "max_swap",
         ] {
             let row = doc.lines().find(|l| l.contains(metric)).expect("metric row");
             assert!(row.contains(" - "), "expected dash in {metric} row: {row}");

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -70,6 +70,9 @@ pub struct ProcessSnapshot {
     /// per-tick `n_threads` (sum across PIDs) and aggregate `peak_n_threads`
     /// (max of those sums across ticks).
     pub thread_count: Option<u64>,
+    /// Swap bytes currently in use by this process. `None` on platforms
+    /// that do not expose per-process swap (macOS) or when the read fails.
+    pub swap_bytes: Option<u64>,
 }
 
 /// Per-PID accumulator; used to keep the latest seen value of monotonically-
@@ -98,6 +101,9 @@ pub struct SamplerState {
     max_vms_bytes: u64,
     max_uss_bytes: Option<u64>,
     max_pss_bytes: Option<u64>,
+    /// Peak summed swap bytes across the tree (max over ticks). `None` if
+    /// no process ever exposed swap counters (always so on macOS).
+    max_swap_bytes: Option<u64>,
     per_pid: HashMap<i32, ProcessAccum>,
     /// Per-PID cumulative counters at the end of the last tick — used to
     /// compute per-tick *deltas* for the trace TSV. Distinct from the
@@ -142,6 +148,7 @@ struct MemorySums {
     vms: u64,
     uss: Option<u64>,
     pss: Option<u64>,
+    swap: Option<u64>,
 }
 
 /// Cumulative I/O and CPU totals across every PID observed so far. `io_in`
@@ -163,8 +170,10 @@ fn sum_memory(snapshots: &[ProcessSnapshot]) -> MemorySums {
     let mut vms: u64 = 0;
     let mut uss: u64 = 0;
     let mut pss: u64 = 0;
+    let mut swap: u64 = 0;
     let mut any_uss = false;
     let mut any_pss = false;
+    let mut any_swap = false;
     for snap in snapshots {
         rss = rss.saturating_add(snap.rss_bytes);
         vms = vms.saturating_add(snap.vms_bytes);
@@ -176,12 +185,17 @@ fn sum_memory(snapshots: &[ProcessSnapshot]) -> MemorySums {
             pss = pss.saturating_add(v);
             any_pss = true;
         }
+        if let Some(v) = snap.swap_bytes {
+            swap = swap.saturating_add(v);
+            any_swap = true;
+        }
     }
     MemorySums {
         rss,
         vms,
         uss: if any_uss { Some(uss) } else { None },
         pss: if any_pss { Some(pss) } else { None },
+        swap: if any_swap { Some(swap) } else { None },
     }
 }
 
@@ -274,6 +288,9 @@ impl SamplerState {
         if let Some(v) = sums.pss {
             self.max_pss_bytes = Some(self.max_pss_bytes.unwrap_or(0).max(v));
         }
+        if let Some(v) = sums.swap {
+            self.max_swap_bytes = Some(self.max_swap_bytes.unwrap_or(0).max(v));
+        }
         // Instantaneous tree-wide thread + process counts at this tick.
         // Both follow the memory-style "max of per-tick sums" semantics —
         // they are not cumulative counters with deltas.
@@ -354,6 +371,7 @@ impl SamplerState {
             voluntary_ctx_switches: deltas.voluntary_ctx_switches,
             involuntary_ctx_switches: deltas.involuntary_ctx_switches,
             n_threads: sum_thread_count(snapshots),
+            swap: mem.swap.map(bytes_to_mib),
         })
     }
 
@@ -460,6 +478,7 @@ impl SamplerState {
             // sampler's lifetime, not inside the sampler itself.
             loadavg_1m_start: None,
             loadavg_1m_end: None,
+            max_swap: self.max_swap_bytes.map(bytes_to_mib),
             data_collected: true,
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -639,6 +639,58 @@ fn loadavg_is_not_added_to_trace_columns() {
     );
 }
 
+/// Peak swap usage shows up in the aggregate (MiB, summed across the
+/// process tree). The per-tick trace adds a `swap` column with the
+/// instantaneous summed value. macOS has no public per-process swap API,
+/// so both columns render `-` there.
+#[test]
+fn swap_columns_appear_in_aggregate_and_trace() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let trace = tmp.path().join("trace.tsv");
+    let trace_str = trace.to_str().unwrap();
+    let result = run_bench(&out, "tsv", &["--trace", trace_str], &["sh", "-c", "sleep 0.4"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let agg_text = std::fs::read_to_string(&out).expect("aggregate tsv");
+    let agg_header = agg_text.lines().next().expect("header");
+    let agg_cols: Vec<&str> = agg_header.split('\t').collect();
+    let data: Vec<&str> = agg_text.lines().nth(1).expect("data row").split('\t').collect();
+    let pos = |name: &str| {
+        agg_cols.iter().position(|c| *c == name).unwrap_or_else(|| panic!("agg col {name}"))
+    };
+    let max_swap = data[pos("max_swap")];
+    #[cfg(target_os = "linux")]
+    {
+        // Linux has VmSwap in /proc/<pid>/status; for a sleep it's typically
+        // 0.00 MiB but may be any non-negative float.
+        let v: f64 = max_swap.parse().unwrap_or_else(|_| panic!("max_swap parses: {max_swap}"));
+        assert!(v >= 0.0, "linux max_swap {v} must be >= 0");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        assert_eq!(max_swap, "-", "macos max_swap should be `-` (no per-process swap API)");
+    }
+
+    let trace_text = std::fs::read_to_string(&trace).expect("trace tsv");
+    let trace_header = trace_text.lines().next().expect("trace header");
+    assert!(
+        trace_header.split('\t').any(|c| c == "swap"),
+        "trace header missing swap column: {trace_header}",
+    );
+}
+
+#[test]
+fn snakemake_strict_mode_strips_swap_column() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let result = run_bench(&out, "tsv", &["--snakemake"], &["sh", "-c", "sleep 0.3"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let header = std::fs::read_to_string(&out).unwrap().lines().next().unwrap().to_string();
+    assert!(!header.contains("max_swap"), "strict header: {header}");
+}
+
 fn python3_available() -> bool {
     Command::new("python3").arg("--version").output().is_ok_and(|o| o.status.success())
 }


### PR DESCRIPTION
Final metric off tracking issue #11. Stacks on #17 → #16 → #15 → #14 → #13.

## Summary

- Adds **peak swap usage** (`max_swap`) to the aggregate and **per-tick `swap`** to the trace. Both follow the existing memory-style semantics (instantaneous summed across the live tree, peak across ticks for the aggregate).
- Linux reads `VmSwap` from `/proc/<pid>/status` (kB → bytes). macOS has no public per-process swap API, so both columns stay `None` and render as `-` / `null` — same pattern as `minor_page_faults` and the ctx-switch columns on macOS.

## Why bother

`VmSwap` surfaces silent memory pressure that `max_rss` alone misses: "the kernel pushed 200 MiB to swap mid-run and pulled it back; RSS shows 50 MiB but the workload was actually 250 MiB."

## Test plan

- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [x] `cargo ci-test` — 89 tests pass (was 87; +2 integration tests for swap cols and strict-mode strip)
- [x] `cargo test --doc` clean

## End of the #11 backlog

This closes the final checkbox in #11. After this stack lands the schema is: 10 Snakemake columns + 9 `tricord`-added columns under full mode, with `--snakemake` available as a single-flag escape hatch for downstream tools that pin to the original schema. Per-tick trace adds 6 columns (`major_page_faults`, `minor_page_faults`, `voluntary_ctx_switches`, `involuntary_ctx_switches`, `n_threads`, `swap`) to the 9 it already had.

Closes the swap-usage checkbox on #11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added swap memory metrics to reports: `max_swap` (aggregate) and `swap` (per-tick). Linux reports actual values; macOS shows unavailable.

* **Documentation**
  * Updated output schema, examples, and platform notes to document new swap columns and macOS behavior. Snakemake-strict mode still omits these fields.

* **Tests**
  * Added/updated tests to verify TSV headers, rows, parsing, and platform-specific expectations for swap metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/tricord/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
