### PR TITLE
docs: add Zenodo DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Documentation at docs.rs](https://img.shields.io/docsrs/tricord)](https://docs.rs/tricord)
 [![codecov](https://codecov.io/gh/fg-labs/tricord/graph/badge.svg)](https://codecov.io/gh/fg-labs/tricord)
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/fg-labs/tricord/blob/main/LICENSE)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21445775.svg)](https://doi.org/10.5281/zenodo.21445775)
 
 # tricord
 


### PR DESCRIPTION
tricord is now archived on Zenodo via the GitHub integration, with its release history backfilled.

This adds a DOI badge using `10.5281/zenodo.21445775`, the concept DOI covering all versions, which always resolves to the latest release.

Verified: the concept DOI covers all four releases in a single version series.

One note for reviewers: the backfill deposited `v0.1.2` immediately after `v0.1.3`, and Zenodo's latest-version pointer follows deposition order rather than semantic version, so the concept DOI currently resolves to `v0.1.2`. This corrects itself on the next release, since that deposition lands last — see #27.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Zenodo DOI badge to the README for easier access to the project’s archived release record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->