### PR TITLE
feat(record): track system page-cache size at run start and end

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Snakemake schema; the prefix's column order and value formatting are
 identical in both modes.
 
 ```text
-s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches	peak_n_threads	peak_n_procs	loadavg_1m_start	loadavg_1m_end	max_swap
-12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60	42	1234	80	7	13	4	0.50	2.25	64.00
+s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_page_faults	minor_page_faults	voluntary_ctx_switches	involuntary_ctx_switches	peak_n_threads	peak_n_procs	loadavg_1m_start	loadavg_1m_end	max_swap	page_cache_start	page_cache_end
+12.3456	0:00:12	101.50	2048.00	95.20	96.00	1.25	0.50	175.00	21.60	42	1234	80	7	13	4	0.50	2.25	64.00	512.00	480.25
 ```
 
 | Column | Units | Meaning |
@@ -133,6 +133,8 @@ s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time	major_pa
 | `loadavg_1m_start` | float (`%.2f`) | System 1-minute load average sampled just before the child started. Frames the rest of the numbers — a peak `cpu_time` of 800% on an idle host (loadavg ~1) means something very different from the same peak on a thrashing host. `tricord`-added; omitted under `--snakemake`. |
 | `loadavg_1m_end` | float (`%.2f`) | System 1-minute load average sampled just after the child exited. Paired with `loadavg_1m_start` to show whether the run drove the host load up. `tricord`-added; omitted under `--snakemake`. |
 | `max_swap` | MiB | Peak summed swap usage across the process tree (max over sampling ticks of `VmSwap` summed across PIDs). `tricord`-added; omitted under `--snakemake`. Always `-` on macOS — the kernel has no public per-process swap-usage API. |
+| `page_cache_start` | MiB | System page-cache size (`Cached` in `/proc/meminfo`) sampled just before the child started. Frames the memory numbers the same way `loadavg_1m_start` frames CPU numbers: a run slowed by page-cache eviction from other work on the host looks identical to a real regression without it. `tricord`-added; omitted under `--snakemake`. On macOS renders `-` (no `Cached` equivalent) once a sample was taken, or `NA` like every other resource column if the run ended before the first sample — see [Platform notes](#platform-notes). |
+| `page_cache_end` | MiB | System page-cache size sampled just after the child exited. Paired with `page_cache_start` — a drop is a direct sign the run (or a neighbor) evicted cached pages. `tricord`-added; omitted under `--snakemake`. On macOS renders `-` once a sample was taken, or `NA` if the run ended before the first sample. |
 
 Missing values render as `-`; if the run was too short for any sample to
 succeed, every resource column is `NA`.
@@ -172,7 +174,7 @@ The trace is `tricord`-native and is **not** affected by `--snakemake`.
 Default (full) mode includes `tricord`-added fields:
 
 ```json
-{"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"major_page_faults":42,"minor_page_faults":1234,"voluntary_ctx_switches":80,"involuntary_ctx_switches":7,"peak_n_threads":13,"peak_n_procs":4,"loadavg_1m_start":0.50,"loadavg_1m_end":2.25,"max_swap":64.0,"data_collected":true}
+{"running_time":12.3456,"max_rss":101.5,"max_vms":2048.0,"max_uss":95.2,"max_pss":96.0,"io_in":1.25,"io_out":0.5,"mean_load":175.0,"cpu_time":21.6,"major_page_faults":42,"minor_page_faults":1234,"voluntary_ctx_switches":80,"involuntary_ctx_switches":7,"peak_n_threads":13,"peak_n_procs":4,"loadavg_1m_start":0.50,"loadavg_1m_end":2.25,"max_swap":64.0,"page_cache_start":512.0,"page_cache_end":480.25,"data_collected":true}
 ```
 
 Under `--snakemake` the `tricord`-added keys are *absent* from the object
@@ -232,6 +234,7 @@ macOS implementation uses [`libproc`]'s `proc_pidinfo` and `proc_pid_rusage`
 | `peak_n_threads`, `n_threads` | `/proc/<pid>/status` (`threads`) | `proc_taskinfo::pti_threadnum` |
 | `loadavg_1m_start`, `loadavg_1m_end` | `/proc/loadavg` (first field) | `getloadavg(3)` |
 | `max_swap`, `swap` | `/proc/<pid>/status` (`VmSwap`) | not exposed — both columns are `-` |
+| `page_cache_start`, `page_cache_end` | `/proc/meminfo` (`Cached`) | not exposed — both columns are `-` once a sample was taken, or `NA` if the run ended before the first sample (matching every other resource column). macOS's VM system does not track file-backed page-cache pages as a separate, directly comparable quantity. |
 
 ### macOS PSS approximation
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -126,6 +126,8 @@ mod tests {
             loadavg_1m_start: Some(0.75),
             loadavg_1m_end: Some(1.10),
             max_swap: Some(0.25),
+            page_cache_start: Some(256.0),
+            page_cache_end: Some(240.0),
             data_collected: true,
         }
     }
@@ -141,13 +143,14 @@ mod tests {
         assert!(lines[0].contains("\tvoluntary_ctx_switches\tinvoluntary_ctx_switches\t"));
         assert!(lines[0].contains("\tpeak_n_threads\tpeak_n_procs\t"));
         assert!(lines[0].contains("\tloadavg_1m_start\tloadavg_1m_end\t"));
-        assert!(lines[0].ends_with("\tmax_swap"));
+        assert!(lines[0].contains("\tmax_swap\t"));
+        assert!(lines[0].ends_with("\tpage_cache_start\tpage_cache_end"));
         assert!(lines[1].starts_with("0.5000\t"));
         // sample_record(): major=3 minor=120 voluntary=40 involuntary=5
         //                  peak_n_threads=6 peak_n_procs=2 loadavg 0.75 → 1.10
-        //                  max_swap=0.25
+        //                  max_swap=0.25 page_cache 256.0 → 240.0
         assert!(
-            lines[1].ends_with("\t3\t120\t40\t5\t6\t2\t0.75\t1.10\t0.25"),
+            lines[1].ends_with("\t3\t120\t40\t5\t6\t2\t0.75\t1.10\t0.25\t256.00\t240.00"),
             "data row: {}",
             lines[1]
         );

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use procfs::{process, process::Process};
+use procfs::{Current, Meminfo, process, process::Process};
 
 use super::ProcessSampler;
 use crate::sampler::ProcessSnapshot;
@@ -126,6 +126,19 @@ fn sample_process(pid: i32, ticks_per_second: f64) -> Option<ProcessSnapshot> {
 pub fn read_loadavg_1m() -> Option<f64> {
     let text = std::fs::read_to_string("/proc/loadavg").ok()?;
     text.split_whitespace().next()?.parse::<f64>().ok()
+}
+
+/// Read the system page-cache size (`Cached` in `/proc/meminfo`), in MiB.
+///
+/// `Cached` is in-memory storage for file contents read from disk — memory
+/// the kernel reclaims under pressure before it would ever swap, so a value
+/// that drops between two readings is a direct sign the run competed for
+/// cache space with other work on the host. Returns `None` if `/proc/meminfo`
+/// cannot be read or parsed.
+#[must_use]
+pub fn read_page_cache_mb() -> Option<f64> {
+    let cached_bytes = Meminfo::current().ok()?.cached;
+    Some(cached_bytes as f64 / (1024.0 * 1024.0))
 }
 
 /// Parse `/proc/<pid>/smaps_rollup` for USS and PSS. Returns `(None, None)` if

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -50,6 +50,16 @@ pub fn read_loadavg_1m() -> Option<f64> {
     if written < 1 { None } else { Some(buf[0]) }
 }
 
+/// Always `None` on macOS: there is no equivalent of Linux's `Cached` page
+/// cache. macOS's VM system unifies the page cache into the general free/
+/// active/inactive page accounting (`vm_stat`/`host_statistics64`) rather
+/// than tracking file-backed cache pages as a separate, directly comparable
+/// quantity, so there is no single number that means the same thing.
+#[must_use]
+pub fn read_page_cache_mb() -> Option<f64> {
+    None
+}
+
 /// `(numer, denom)` from `mach_timebase_info`, cached once per process.
 ///
 /// `pti_total_user` / `pti_total_system` are in Mach absolute time units,

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -55,3 +55,23 @@ pub fn read_loadavg_1m() -> Option<f64> {
         macos::read_loadavg_1m()
     }
 }
+
+/// Read the system page-cache size, in MiB.
+///
+/// Returns `None` if the platform read fails, or unconditionally on macOS,
+/// which has no equivalent of Linux's `Cached` accounting — see
+/// `macos::read_page_cache_mb`. Used by `run_command` to snapshot system
+/// context at run start and end, the same way `read_loadavg_1m` frames CPU
+/// pressure: a workload slowed by page-cache eviction from other work on the
+/// host looks identical to a real regression without this.
+#[must_use]
+pub fn read_page_cache_mb() -> Option<f64> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::read_page_cache_mb()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos::read_page_cache_mb()
+    }
+}

--- a/src/record.rs
+++ b/src/record.rs
@@ -22,7 +22,8 @@ pub const TSV_HEADER_FULL: &str = "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\
                                    voluntary_ctx_switches\tinvoluntary_ctx_switches\t\
                                    peak_n_threads\tpeak_n_procs\t\
                                    loadavg_1m_start\tloadavg_1m_end\t\
-                                   max_swap";
+                                   max_swap\t\
+                                   page_cache_start\tpage_cache_end";
 
 /// Return the appropriate aggregate header for the requested schema mode.
 #[must_use]
@@ -213,6 +214,20 @@ pub struct BenchmarkRecord {
     /// no process exposed swap counters during the run — always `None` on
     /// macOS (the kernel has no public per-process swap-usage API).
     pub max_swap: Option<f64>,
+    /// System page-cache size (`Cached` in `/proc/meminfo`) sampled just
+    /// before the child started, in MiB. `None` if the platform read
+    /// failed — always `None` on macOS, which has no equivalent of Linux's
+    /// `Cached` accounting.
+    pub page_cache_start: Option<f64>,
+    /// System page-cache size sampled just after the child exited, in MiB.
+    /// `None` if the platform read failed — always `None` on macOS.
+    /// Pairing start + end frames the resource numbers the same way
+    /// `loadavg_1m_start`/`loadavg_1m_end` do, for memory pressure instead
+    /// of CPU pressure: a run that got slower because its working set was
+    /// evicted from cache by other work on the host looks identical to a
+    /// real regression without this — a drop from start to end is the
+    /// signal.
+    pub page_cache_end: Option<f64>,
     /// Whether at least one sample successfully read OS resource counters.
     ///
     /// When `false` the TSV row is rendered with `NA` placeholders for every
@@ -236,8 +251,8 @@ impl BenchmarkRecord {
 
         let extra_cols = match mode {
             // page faults (2) + ctx switches (2) + peak n_threads + n_procs
-            // + loadavg start/end (2) + max_swap = 9
-            SchemaMode::Full => 9,
+            // + loadavg start/end (2) + max_swap + page_cache start/end (2) = 11
+            SchemaMode::Full => 11,
             SchemaMode::SnakemakeStrict => 0,
         };
 
@@ -269,7 +284,13 @@ impl BenchmarkRecord {
             // peak_n_procs is a plain `u64`, not Option, so render bare —
             // when `data_collected` is true it's always populated.
             write!(out, "\t{}", self.peak_n_procs).unwrap();
-            for value in [self.loadavg_1m_start, self.loadavg_1m_end, self.max_swap] {
+            for value in [
+                self.loadavg_1m_start,
+                self.loadavg_1m_end,
+                self.max_swap,
+                self.page_cache_start,
+                self.page_cache_end,
+            ] {
                 out.push('\t');
                 out.push_str(&format_optional_float(value));
             }
@@ -372,6 +393,8 @@ impl BenchmarkRecord {
             rows.push(("loadavg_1m_start", cell(self.loadavg_1m_start)));
             rows.push(("loadavg_1m_end", cell(self.loadavg_1m_end)));
             rows.push(("max_swap", cell(self.max_swap)));
+            rows.push(("page_cache_start", cell(self.page_cache_start)));
+            rows.push(("page_cache_end", cell(self.page_cache_end)));
         }
         rows
     }
@@ -493,6 +516,8 @@ mod tests {
             loadavg_1m_start: Some(0.50),
             loadavg_1m_end: Some(2.25),
             max_swap: Some(64.00),
+            page_cache_start: Some(512.00),
+            page_cache_end: Some(480.25),
             data_collected: true,
         }
     }
@@ -520,6 +545,8 @@ mod tests {
             "involuntary_ctx_switches",
             "peak_n_threads",
             "peak_n_procs",
+            "page_cache_start",
+            "page_cache_end",
         ] {
             assert!(full_cols.contains(&col), "missing {col} in {TSV_HEADER_FULL}");
         }
@@ -581,11 +608,12 @@ mod tests {
     #[test]
     fn tsv_row_full_mode_appends_all_tricord_columns() {
         // full_record(): page faults 42/1234, ctx switches 80/7, peak
-        // threads 13, peak procs 4, loadavg 0.50 → 2.25, max_swap 64.00.
+        // threads 13, peak procs 4, loadavg 0.50 → 2.25, max_swap 64.00,
+        // page_cache 512.00 → 480.25.
         assert_eq!(
             full_record().to_tsv_row(SchemaMode::Full),
             "12.3456\t0:00:12\t101.50\t2048.00\t95.20\t96.00\t1.25\t0.50\t175.00\t21.60\t\
-             42\t1234\t80\t7\t13\t4\t0.50\t2.25\t64.00",
+             42\t1234\t80\t7\t13\t4\t0.50\t2.25\t64.00\t512.00\t480.25",
         );
     }
 
@@ -602,7 +630,8 @@ mod tests {
     fn tsv_row_full_mode_renders_missing_tricord_metrics_as_dash() {
         // Option-typed tricord metrics render as `-` when None; the plain
         // `peak_n_procs: u64` renders as its bare integer (full_record's 4).
-        // Loadavg + max_swap fields are Option<f64>, also render as `-`.
+        // Loadavg, max_swap, and page_cache fields are Option<f64>, also
+        // render as `-`.
         let record = BenchmarkRecord {
             major_page_faults: None,
             minor_page_faults: None,
@@ -612,10 +641,12 @@ mod tests {
             loadavg_1m_start: None,
             loadavg_1m_end: None,
             max_swap: None,
+            page_cache_start: None,
+            page_cache_end: None,
             ..full_record()
         };
         let row = record.to_tsv_row(SchemaMode::Full);
-        assert!(row.ends_with("\t-\t-\t-\t-\t-\t4\t-\t-\t-"), "row was: {row}");
+        assert!(row.ends_with("\t-\t-\t-\t-\t-\t4\t-\t-\t-\t-\t-"), "row was: {row}");
     }
 
     #[test]
@@ -724,9 +755,9 @@ mod tests {
 
     #[test]
     fn markdown_full_data_exact_layout() {
-        // Widest label is still "involuntary_ctx_switches" (24 chars); PR 4
-        // adds "loadavg_1m_start"/"loadavg_1m_end" (16 chars) — narrower,
-        // so widths don't shift. Two new rows at the bottom.
+        // Widest label is still "involuntary_ctx_switches" (24 chars);
+        // "page_cache_start"/"page_cache_end" (16/14 chars) are narrower, so
+        // widths don't shift. Two new rows at the bottom.
         //
         // When new metrics land (tracking issue #11 on fg-labs/tricord), this
         // golden block needs re-recording — both for the new rows and for any
@@ -753,6 +784,8 @@ mod tests {
 | loadavg_1m_start         |    0.50 |
 | loadavg_1m_end           |    2.25 |
 | max_swap                 |   64.00 |
+| page_cache_start         |  512.00 |
+| page_cache_end           |  480.25 |
 ";
         assert_eq!(full_record().to_markdown_document(SchemaMode::Full), expected);
     }
@@ -814,6 +847,8 @@ mod tests {
             loadavg_1m_start: None,
             loadavg_1m_end: None,
             max_swap: None,
+            page_cache_start: None,
+            page_cache_end: None,
             data_collected: true,
         };
         let doc = record.to_markdown_document(SchemaMode::Full);
@@ -829,6 +864,8 @@ mod tests {
             "loadavg_1m_start",
             "loadavg_1m_end",
             "max_swap",
+            "page_cache_start",
+            "page_cache_end",
         ] {
             let row = doc.lines().find(|l| l.contains(metric)).expect("metric row");
             assert!(row.contains(" - "), "expected dash in {metric} row: {row}");

--- a/src/run.rs
+++ b/src/run.rs
@@ -75,6 +75,14 @@ pub fn run_command(command: &str, args: &[String], options: &RunOptions) -> io::
     // and the user loses data with no warning.
     validate_output_paths(options)?;
 
+    // Snapshot system loadavg and page-cache size before the child spawns
+    // so the "start" values reflect state entering the run (before our
+    // child has had time to contribute meaningfully to the loadavg EMA, or
+    // to perturb the page cache with its own reads/writes) — not state the
+    // child has already touched.
+    let loadavg_start = platform::read_loadavg_1m();
+    let page_cache_start = platform::read_page_cache_mb();
+
     let mut cmd = Command::new(command);
     cmd.args(args);
     cmd.stdin(Stdio::inherit());
@@ -89,10 +97,6 @@ pub fn run_command(command: &str, args: &[String], options: &RunOptions) -> io::
     // Install signal forwarding before the sampler so a fast Ctrl-C still
     // reaches the child even if the sampler thread hasn't started yet.
     let signals = SignalForwarder::install(child_pid)?;
-    // Snapshot system loadavg just before the sampler starts so the
-    // "start" value reflects load entering the run (before our child has
-    // had time to contribute meaningfully to the EMA).
-    let loadavg_start = platform::read_loadavg_1m();
     let sampler = SamplerHandle::spawn(
         child_pid,
         SamplerOptions { interval: options.interval, trace_path: options.trace_path.clone() },
@@ -101,8 +105,11 @@ pub fn run_command(command: &str, args: &[String], options: &RunOptions) -> io::
     let status = child.wait()?;
     let mut record = sampler.stop();
     let loadavg_end = platform::read_loadavg_1m();
+    let page_cache_end = platform::read_page_cache_mb();
     record.loadavg_1m_start = loadavg_start;
     record.loadavg_1m_end = loadavg_end;
+    record.page_cache_start = page_cache_start;
+    record.page_cache_end = page_cache_end;
     drop(signals);
 
     format::write_to_path(&record, &options.output_path, options.format, options.schema_mode)?;

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -474,11 +474,13 @@ impl SamplerState {
             involuntary_ctx_switches: cum.involuntary_ctx_switches,
             peak_n_threads: self.max_n_threads,
             peak_n_procs: self.max_n_procs,
-            // Loadavg start/end are captured by run_command around the
-            // sampler's lifetime, not inside the sampler itself.
+            // Loadavg and page-cache start/end are captured by run_command
+            // around the sampler's lifetime, not inside the sampler itself.
             loadavg_1m_start: None,
             loadavg_1m_end: None,
             max_swap: self.max_swap_bytes.map(bytes_to_mib),
+            page_cache_start: None,
+            page_cache_end: None,
             data_collected: true,
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -691,6 +691,69 @@ fn snakemake_strict_mode_strips_swap_column() {
     assert!(!header.contains("max_swap"), "strict header: {header}");
 }
 
+/// System page-cache size (`Cached` in `/proc/meminfo`) is sampled at start
+/// and end of the run and added as two aggregate columns, mirroring
+/// `loadavg_1m_start`/`loadavg_1m_end`. macOS has no equivalent of Linux's
+/// `Cached` accounting, so both columns render `-` there.
+#[test]
+fn page_cache_start_and_end_appear_in_aggregate_tsv() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let result = run_bench(&out, "tsv", &[], &["sh", "-c", "sleep 0.3"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let text = std::fs::read_to_string(&out).expect("aggregate tsv");
+    let header = text.lines().next().expect("header");
+    let header_cols: Vec<&str> = header.split('\t').collect();
+    let cols: Vec<&str> = text.lines().nth(1).expect("data row").split('\t').collect();
+    let pos = |name: &str| {
+        header_cols.iter().position(|c| *c == name).unwrap_or_else(|| panic!("col {name}"))
+    };
+    let start = cols[pos("page_cache_start")];
+    let end = cols[pos("page_cache_end")];
+    #[cfg(target_os = "linux")]
+    {
+        let start_v: f64 = start.parse().unwrap_or_else(|_| panic!("page_cache_start: {start}"));
+        let end_v: f64 = end.parse().unwrap_or_else(|_| panic!("page_cache_end: {end}"));
+        assert!(start_v >= 0.0, "page_cache_start {start_v} must be >= 0 on any real Linux host");
+        assert!(end_v >= 0.0, "page_cache_end {end_v} must be >= 0 on any real Linux host");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        assert_eq!(start, "-", "macos page_cache_start should be `-` (no Cached equivalent)");
+        assert_eq!(end, "-", "macos page_cache_end should be `-` (no Cached equivalent)");
+    }
+}
+
+#[test]
+fn snakemake_strict_mode_strips_page_cache_columns() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let result = run_bench(&out, "tsv", &["--snakemake"], &["sh", "-c", "sleep 0.3"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let header = std::fs::read_to_string(&out).unwrap().lines().next().unwrap().to_string();
+    assert!(!header.contains("page_cache_start"), "strict header: {header}");
+    assert!(!header.contains("page_cache_end"), "strict header: {header}");
+}
+
+#[test]
+fn page_cache_is_not_added_to_trace_columns() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.tsv");
+    let trace = tmp.path().join("trace.tsv");
+    let trace_str = trace.to_str().unwrap();
+    let result = run_bench(&out, "tsv", &["--trace", trace_str], &["sh", "-c", "sleep 0.4"]);
+    assert!(result.status.success(), "stderr: {}", String::from_utf8_lossy(&result.stderr));
+
+    let trace_header = std::fs::read_to_string(&trace).unwrap().lines().next().unwrap().to_string();
+    assert!(
+        !trace_header.contains("page_cache"),
+        "trace TSV must not include page_cache (system-wide, not a per-process/per-tick \
+         quantity the way rss/io/cpu are): {trace_header}",
+    );
+}
+
 fn python3_available() -> bool {
     Command::new("python3").arg("--version").output().is_ok_and(|o| o.status.success())
 }


### PR DESCRIPTION
## Summary

Adds `page_cache_start`/`page_cache_end` (MiB, from `/proc/meminfo`'s `Cached`), sampled the same way as `loadavg_1m_start`/`loadavg_1m_end` — once just before the child spawns, once just after it exits.

Motivated by a `bwa-mem3-bench` investigation into arena wall-clock drift: per-process metrics (page faults, IO bytes via `--trace`) already exist, but couldn't rule out *system-wide* memory pressure as a cause of an apparent regression that turned out to be a measurement artifact. This closes that gap for future investigations, and per #11 the value generalizes well beyond that one use case — any workload slowed by page-cache eviction from other work on the host looks identical to a real regression without it.

Closes the "Page cache size" item on #11.

## Design (per #11's own guiding constraints)

- **On by default**, opted out via the existing `--snakemake` strict mode — no new flag.
- **New column appended to the end** of `TSV_HEADER_FULL`, after `max_swap`. Existing column order/formatting untouched.
- **Not added to the per-tick trace**, following `loadavg`'s own precedent exactly: it's a system-wide reading taken once per run boundary, not a per-process, per-tick quantity the way `rss`/`io`/`cpu` are.
- **macOS**: always `None`. There is no equivalent of Linux's `Cached` page-cache accounting — macOS's VM system doesn't track file-backed cache pages as a separate, directly comparable quantity (see the doc comment on `platform::macos::read_page_cache_mb`).
- Implemented via `procfs::Meminfo::current()` (already a dependency, no new crate).

## Testing

- Unit tests in `record.rs`/`format.rs` updated to cover the two new columns in TSV, Markdown, and the `--snakemake`-omission path (mirroring every existing metric's test shape).
- Three new integration tests in `tests/integration.rs`, mirroring `loadavg`'s and `swap`'s exact test shapes: values appear in the aggregate TSV (real value on Linux, `-` on macOS), `--snakemake` strips them, and they're absent from the trace TSV.
- Verified the Linux code path compiles and lints clean via `cargo check --target x86_64-unknown-linux-gnu` and `cargo clippy --target x86_64-unknown-linux-gnu --all-targets --all-features -- -D warnings` (I'm on macOS, so this is the only way to exercise the Linux-specific `procfs::Meminfo` usage before CI does).
- `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` (101/101) all green on macOS.
- Self-reviewed with a CodeRabbit-style pass before pushing; one nitpick found and fixed (a stray `Cached:` vs `Cached` doc-comment inconsistency), zero actionable findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page-cache start and end metrics to aggregate benchmark output.
  * Linux reports cached memory in MiB; macOS marks the metric as unavailable.
  * Included page-cache fields in JSON, Markdown, and full TSV outputs.

* **Bug Fixes**
  * Ensured strict Snakemake and trace TSV formats remain unchanged.

* **Tests**
  * Added coverage for page-cache values, platform behavior, and output formats.

* **Documentation**
  * Documented the new columns, data source, and platform availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->