### PR TITLE
feat(format): add json-pretty output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ memory, and disk I/O it used. The companion binary is named `tricorder`.
 Think of it as a more thorough `/usr/bin/time -v`: it polls the process tree
 on an interval, follows children and grandchildren, and writes a single
 record summarising peak memory, total bytes read/written, average CPU load,
-and total CPU time. Output is either a tidy TSV or one-line JSON, suited to
-both spreadsheets and pipelines.
+and total CPU time. Output is a tidy TSV, one-line JSON, or pretty-printed
+JSON, suited to spreadsheets, pipelines, and human readers.
 
 <p>
 <a href="https://fulcrumgenomics.com">
@@ -33,9 +33,10 @@ both spreadsheets and pipelines.
 
 - **Whole-tree accounting** — follows forked children and aggregates their
   resource usage; an exited child's I/O is still counted.
-- **Two output formats** — TSV (Snakemake-compatible prefix, extended with
-  `tricord`-specific columns by default) or one-line JSON (`--format json`)
-  for programmatic consumers. Pass `--snakemake` to emit the strict 10-column
+- **Three output formats** — TSV (Snakemake-compatible prefix, extended with
+  `tricord`-specific columns by default), one-line JSON (`--format json`)
+  for programmatic consumers, or pretty-printed JSON (`--format json_pretty`)
+  for human readers. Pass `--snakemake` to emit the strict 10-column
   Snakemake schema when downstream tooling pins to it.
 - **Optional one-line summary** to stderr (`--summary`).
 - **Optional per-tick trace** (`--trace <PATH>`) — one TSV row per sample, so
@@ -79,7 +80,7 @@ Usage: tricorder [OPTIONS] --out <PATH> -- <CMD>...
 
 Options:
       --out <PATH>           Output file path
-      --format <FORMAT>      tsv | json [default: tsv]
+      --format <FORMAT>      tsv | json | json_pretty [default: tsv]
       --interval <SECONDS>   Sampling interval [default: 0.5]
       --summary              Print one-line summary to stderr after the run
       --trace <PATH>         Also write a per-tick TSV trace to this path

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ JSON, suited to spreadsheets, pipelines, and human readers.
   resource usage; an exited child's I/O is still counted.
 - **Three output formats** — TSV (Snakemake-compatible prefix, extended with
   `tricord`-specific columns by default), one-line JSON (`--format json`)
-  for programmatic consumers, or pretty-printed JSON (`--format json_pretty`)
+  for programmatic consumers, or pretty-printed JSON (`--format json-pretty`)
   for human readers. Pass `--snakemake` to emit the strict 10-column
   Snakemake schema when downstream tooling pins to it.
 - **Optional one-line summary** to stderr (`--summary`).
@@ -80,7 +80,7 @@ Usage: tricorder [OPTIONS] --out <PATH> -- <CMD>...
 
 Options:
       --out <PATH>           Output file path
-      --format <FORMAT>      tsv | json | json_pretty [default: tsv]
+      --format <FORMAT>      tsv | json | json-pretty [default: tsv]
       --interval <SECONDS>   Sampling interval [default: 0.5]
       --summary              Print one-line summary to stderr after the run
       --trace <PATH>         Also write a per-tick TSV trace to this path

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,6 +75,9 @@ pub enum Format {
     Tsv,
     /// Single JSON object on one line.
     Json,
+    /// Single JSON object, pretty-printed across multiple lines.
+    #[value(name = "json_pretty", alias = "json-pretty")]
+    JsonPretty,
 }
 
 impl From<Format> for OutputFormat {
@@ -82,6 +85,7 @@ impl From<Format> for OutputFormat {
         match value {
             Format::Tsv => Self::Tsv,
             Format::Json => Self::Json,
+            Format::JsonPretty => Self::JsonPretty,
         }
     }
 }
@@ -138,6 +142,22 @@ mod tests {
         ]);
         assert_eq!(args.format, Format::Json);
         assert!(args.summary);
+    }
+
+    #[test]
+    fn parses_json_pretty_format() {
+        for value in ["json_pretty", "json-pretty"] {
+            let args = Args::parse_from([
+                "tricorder",
+                "--out",
+                "out.json",
+                "--format",
+                value,
+                "--",
+                "true",
+            ]);
+            assert_eq!(args.format, Format::JsonPretty);
+        }
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,7 +76,6 @@ pub enum Format {
     /// Single JSON object on one line.
     Json,
     /// Single JSON object, pretty-printed across multiple lines.
-    #[value(name = "json_pretty", alias = "json-pretty")]
     JsonPretty,
 }
 
@@ -146,18 +145,16 @@ mod tests {
 
     #[test]
     fn parses_json_pretty_format() {
-        for value in ["json_pretty", "json-pretty"] {
-            let args = Args::parse_from([
-                "tricorder",
-                "--out",
-                "out.json",
-                "--format",
-                value,
-                "--",
-                "true",
-            ]);
-            assert_eq!(args.format, Format::JsonPretty);
-        }
+        let args = Args::parse_from([
+            "tricorder",
+            "--out",
+            "out.json",
+            "--format",
+            "json-pretty",
+            "--",
+            "true",
+        ]);
+        assert_eq!(args.format, Format::JsonPretty);
     }
 
     #[test]

--- a/src/format.rs
+++ b/src/format.rs
@@ -15,6 +15,8 @@ pub enum OutputFormat {
     Tsv,
     /// Single JSON object, one line, no trailing newline.
     Json,
+    /// Single JSON object, pretty-printed.
+    JsonPretty,
 }
 
 impl OutputFormat {
@@ -23,7 +25,7 @@ impl OutputFormat {
     pub fn extension(self) -> &'static str {
         match self {
             Self::Tsv => "tsv",
-            Self::Json => "json",
+            Self::Json | Self::JsonPretty => "json",
         }
     }
 }
@@ -75,6 +77,10 @@ pub fn write_to<W: Write>(
         OutputFormat::Tsv => writer.write_all(record.to_tsv_document(mode).as_bytes()),
         OutputFormat::Json => {
             let json = record.to_json(mode).map_err(io::Error::other)?;
+            writer.write_all(json.as_bytes())
+        }
+        OutputFormat::JsonPretty => {
+            let json = record.to_json_pretty(mode).map_err(io::Error::other)?;
             writer.write_all(json.as_bytes())?;
             writer.write_all(b"\n")
         }
@@ -86,7 +92,7 @@ pub fn write_to<W: Write>(
 ///
 /// Lives alongside [`write_to_path`] but takes no `OutputFormat`: Markdown is
 /// a sidecar output (`--export-markdown`) that can be requested alongside the
-/// primary `--out`/`--format` file, not a third value of `--format`.
+/// primary `--out`/`--format` file, not a value of `--format`.
 ///
 /// # Errors
 /// Returns any I/O error from the file system.
@@ -130,6 +136,13 @@ mod tests {
             page_cache_end: Some(240.0),
             data_collected: true,
         }
+    }
+
+    #[test]
+    fn extension_matches_each_format() {
+        assert_eq!(OutputFormat::Tsv.extension(), "tsv");
+        assert_eq!(OutputFormat::Json.extension(), "json");
+        assert_eq!(OutputFormat::JsonPretty.extension(), "json");
     }
 
     #[test]
@@ -185,6 +198,32 @@ mod tests {
     fn json_writer_strict_mode_omits_tricord_fields() {
         let mut buf = Vec::new();
         write_to(&sample_record(), &mut buf, OutputFormat::Json, SchemaMode::SnakemakeStrict)
+            .unwrap();
+        let text = std::str::from_utf8(&buf).unwrap().trim_end();
+        let value: serde_json::Value = serde_json::from_str(text).unwrap();
+        let obj = value.as_object().unwrap();
+        assert!(!obj.contains_key("major_page_faults"));
+        assert!(!obj.contains_key("minor_page_faults"));
+    }
+
+    #[test]
+    fn json_pretty_writer_full_mode_includes_tricord_fields() {
+        let mut buf = Vec::new();
+        write_to(&sample_record(), &mut buf, OutputFormat::JsonPretty, SchemaMode::Full).unwrap();
+        let text = std::str::from_utf8(&buf).unwrap().trim_end();
+        // One line per field (21 in full mode) plus the two brace lines.
+        assert_eq!(text.lines().count(), 23, "pretty output: {text}");
+        let value: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert!(value.is_object());
+        assert_eq!(value["data_collected"], true);
+        assert_eq!(value["major_page_faults"], 3);
+        assert_eq!(value["minor_page_faults"], 120);
+    }
+
+    #[test]
+    fn json_pretty_writer_strict_mode_omits_tricord_fields() {
+        let mut buf = Vec::new();
+        write_to(&sample_record(), &mut buf, OutputFormat::JsonPretty, SchemaMode::SnakemakeStrict)
             .unwrap();
         let text = std::str::from_utf8(&buf).unwrap().trim_end();
         let value: serde_json::Value = serde_json::from_str(text).unwrap();

--- a/src/format.rs
+++ b/src/format.rs
@@ -15,7 +15,7 @@ pub enum OutputFormat {
     Tsv,
     /// Single JSON object, one line, no trailing newline.
     Json,
-    /// Single JSON object, pretty-printed.
+    /// Single JSON object, pretty-printed, with a trailing newline.
     JsonPretty,
 }
 
@@ -207,6 +207,14 @@ mod tests {
     }
 
     #[test]
+    fn json_writer_emits_no_trailing_newline() {
+        let mut buf = Vec::new();
+        write_to(&sample_record(), &mut buf, OutputFormat::Json, SchemaMode::Full).unwrap();
+        let text = std::str::from_utf8(&buf).unwrap();
+        assert!(!text.ends_with('\n'), "unexpected trailing newline: {text:?}");
+    }
+
+    #[test]
     fn json_pretty_writer_full_mode_includes_tricord_fields() {
         let mut buf = Vec::new();
         write_to(&sample_record(), &mut buf, OutputFormat::JsonPretty, SchemaMode::Full).unwrap();
@@ -230,6 +238,14 @@ mod tests {
         let obj = value.as_object().unwrap();
         assert!(!obj.contains_key("major_page_faults"));
         assert!(!obj.contains_key("minor_page_faults"));
+    }
+
+    #[test]
+    fn json_pretty_writer_emits_trailing_newline() {
+        let mut buf = Vec::new();
+        write_to(&sample_record(), &mut buf, OutputFormat::JsonPretty, SchemaMode::Full).unwrap();
+        let text = std::str::from_utf8(&buf).unwrap();
+        assert!(text.ends_with('\n'), "missing trailing newline: {text:?}");
     }
 
     #[test]

--- a/src/record.rs
+++ b/src/record.rs
@@ -322,9 +322,24 @@ impl BenchmarkRecord {
     /// Returns an error only if `serde_json` itself fails (which should not
     /// happen for this struct).
     pub fn to_json(&self, mode: SchemaMode) -> serde_json::Result<String> {
+        self.to_json_string(mode, false)
+    }
+
+    /// Like [`Self::to_json`], but pretty-printed.
+    ///
+    /// # Errors
+    /// As for [`Self::to_json`].
+    pub fn to_json_pretty(&self, mode: SchemaMode) -> serde_json::Result<String> {
+        self.to_json_string(mode, true)
+    }
+
+    fn to_json_string(&self, mode: SchemaMode, pretty: bool) -> serde_json::Result<String> {
+        fn to_string<T: serde::Serialize>(value: &T, pretty: bool) -> serde_json::Result<String> {
+            if pretty { serde_json::to_string_pretty(value) } else { serde_json::to_string(value) }
+        }
         match mode {
-            SchemaMode::Full => serde_json::to_string(self),
-            SchemaMode::SnakemakeStrict => serde_json::to_string(&SnakemakeView::from(self)),
+            SchemaMode::Full => to_string(self, pretty),
+            SchemaMode::SnakemakeStrict => to_string(&SnakemakeView::from(self), pretty),
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -82,6 +82,22 @@ fn json_output_round_trips_to_object() {
 }
 
 #[test]
+fn json_pretty_output_round_trips_to_object() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.json");
+    let result = run_bench(&out, "json_pretty", &[], &["sh", "-c", "sleep 0.6"]);
+    assert!(result.status.success());
+
+    let text = std::fs::read_to_string(&out).unwrap();
+    // One line per field (21 in full mode) plus the two brace lines.
+    assert_eq!(text.trim().lines().count(), 23, "pretty output: {text}");
+    let value: serde_json::Value = serde_json::from_str(text.trim()).expect("valid json");
+    assert!(value.is_object());
+    assert!(value["running_time"].as_f64().expect("running_time number") >= 0.5);
+    assert_eq!(value["data_collected"], true);
+}
+
+#[test]
 fn nested_output_directory_is_created() {
     let tmp = tempfile::tempdir().unwrap();
     let out = tmp.path().join("does/not/exist/yet/timing.tsv");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -96,7 +96,7 @@ fn json_output_emits_no_trailing_newline() {
 fn json_pretty_output_round_trips_to_object() {
     let tmp = tempfile::tempdir().unwrap();
     let out = tmp.path().join("timing.json");
-    let result = run_bench(&out, "json_pretty", &[], &["sh", "-c", "sleep 0.6"]);
+    let result = run_bench(&out, "json-pretty", &[], &["sh", "-c", "sleep 0.6"]);
     assert!(result.status.success());
 
     let text = std::fs::read_to_string(&out).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -82,6 +82,17 @@ fn json_output_round_trips_to_object() {
 }
 
 #[test]
+fn json_output_emits_no_trailing_newline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.json");
+    let result = run_bench(&out, "json", &[], &["sh", "-c", "true"]);
+    assert!(result.status.success());
+
+    let text = std::fs::read_to_string(&out).unwrap();
+    assert!(!text.ends_with('\n'), "unexpected trailing newline: {text:?}");
+}
+
+#[test]
 fn json_pretty_output_round_trips_to_object() {
     let tmp = tempfile::tempdir().unwrap();
     let out = tmp.path().join("timing.json");
@@ -95,6 +106,17 @@ fn json_pretty_output_round_trips_to_object() {
     assert!(value.is_object());
     assert!(value["running_time"].as_f64().expect("running_time number") >= 0.5);
     assert_eq!(value["data_collected"], true);
+}
+
+#[test]
+fn json_pretty_output_emits_trailing_newline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("timing.json");
+    let result = run_bench(&out, "json-pretty", &[], &["sh", "-c", "true"]);
+    assert!(result.status.success());
+
+    let text = std::fs::read_to_string(&out).unwrap();
+    assert!(text.ends_with('\n'), "missing trailing newline: {text:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary of changes

Adds `--format json-pretty`, which writes the aggregate record as a pretty-printed JSON object.

- Unit and integration tests mirror the existing `json` coverage, plus an exact line-count check (one line per field, plus braces).
- Drive-by fix: `--format json` no longer emits a trailing newline, as promised in its docstring. Pretty output keeps one.

### Example

`tricorder --out timing.json --format json -- sh -c 'sleep 0.6'` (macOS, so some fields are `null`):

```json
{"running_time":1.001428042,"max_rss":1.203125,"max_vms":431527.03125,"max_uss":0.9377059936523438,"max_pss":0.9377059936523438,"io_in":0.02734375,"io_out":0.0,"mean_load":0.49436069882559436,"cpu_time":0.004950666666666667,"major_page_faults":9,"minor_page_faults":null,"voluntary_ctx_switches":null,"involuntary_ctx_switches":null,"peak_n_threads":1,"peak_n_procs":1,"loadavg_1m_start":5.3603515625,"loadavg_1m_end":5.3603515625,"max_swap":null,"page_cache_start":null,"page_cache_end":null,"data_collected":true}
```

The same run with `--format json-pretty`:

```json
{
  "running_time": 1.005066625,
  "max_rss": 1.203125,
  "max_vms": 431526.75,
  "max_uss": 0.9377059936523438,
  "max_pss": 0.9377059936523438,
  "io_in": 0.0,
  "io_out": 0.0,
  "mean_load": 0.42743849609638235,
  "cpu_time": 0.004296041666666667,
  "major_page_faults": 5,
  "minor_page_faults": null,
  "voluntary_ctx_switches": null,
  "involuntary_ctx_switches": null,
  "peak_n_threads": 1,
  "peak_n_procs": 1,
  "loadavg_1m_start": 5.3603515625,
  "loadavg_1m_end": 5.1708984375,
  "max_swap": null,
  "page_cache_start": null,
  "page_cache_end": null,
  "data_collected": true
}
```

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### :heavy_check_mark: Checklist

- [x] I have checked there are not other open [Pull Requests](../../../pulls) for the same update/change
- [x] I added test case(s) whose failure behavior is different before vs after the change
- [x] All non-obvious additions to the code are thoroughly commented
- [x] All CI checks pass (compile, test, format, lints)
- [x] I added/updated all relevant documentation (e.g., `README.md` and `docs/*`)
- [x] All relevant logs, outputs, screenshots, etc. are attached
- [x] I have followed all the other contributing guidelines not covered by the above items (e.g., git etiquette, branch naming, commit messages)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pretty-printed JSON output through the `json-pretty` format option.
  * Pretty JSON supports both full and strict schema formats.
  * Generated files use the `.json` extension.

* **Documentation**
  * Updated command-line help and README documentation with the new output format.

* **Tests**
  * Added coverage verifying formatted JSON parsing and end-to-end output validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
